### PR TITLE
切版：實作活動創建表單，支持動態方案和圖片上傳

### DIFF
--- a/app/create-activity/components/CreateActivityForm.tsx
+++ b/app/create-activity/components/CreateActivityForm.tsx
@@ -1,0 +1,93 @@
+"use client"
+import React, { useState } from 'react'
+import { useForm, FormProvider } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { FormDataSchema, FormData } from '../schema/formDataSchema'
+import EventStepper from './EventStepper'
+import EventInfoForm from './EventInfoForm'
+import UploadCoverForm from './UploadCoverForm'
+import UploadEventImageForm from './UploadEventImageForm'
+import PlanAccordion from './PlanAccordion'
+
+const CreateActivityForm: React.FC = () => {
+  const methods = useForm<FormData>({
+    resolver: zodResolver(FormDataSchema),
+    mode: 'onChange',
+    defaultValues: {
+      eventInfo: {
+        title: '', organizer: '', location: '',
+        startDate: new Date().toISOString().slice(0, 10),
+        startTime: '00:00', endDate: new Date().toISOString().slice(0, 10),
+        endTime: '00:00', maxParticipants: 1,
+        description: '', tags: '寵物友善', cancelPolicy: false,
+        notifications: [],
+      },
+      coverImages: [],
+      eventImages: [],
+      plans: [
+        { title: '', price: 0, discountPrice: undefined, content: [], addOns: [] }
+      ],
+    },
+  })
+
+  // 步驟導航狀態
+  const [currentStep, setCurrentStep] = useState<number>(1)
+
+  // 驗證指定步驟資料
+  const validateStep = async (step: number) => {
+    switch (step) {
+      case 1: return methods.trigger('eventInfo')
+      case 2: return methods.trigger('coverImages')
+      case 3: return methods.trigger('eventImages')
+      case 4: return methods.trigger('plans')
+      default: return false
+    }
+  }
+
+  const handleNextStep = async () => {
+    const valid = await validateStep(currentStep)
+    if (valid && currentStep < 4) setCurrentStep(currentStep + 1)
+  }
+
+  const handlePrevStep = () => {
+    if (currentStep > 1) setCurrentStep(currentStep - 1)
+  }
+
+  const handleStepChange = async (step: number) => {
+    const checks = Array.from({ length: step - 1 }, (_, i) => validateStep(i + 1))
+    if ((await Promise.all(checks)).every(Boolean)) setCurrentStep(step)
+  }
+
+  return (
+    <FormProvider<FormData> {...methods}>
+      <div className="p-40">
+        <EventStepper
+          currentStep={currentStep}
+          totalSteps={4}
+          stepTitles={[
+            '基本資訊',
+            '活動封面',
+            '活動內容圖片',
+            '方案設計',
+          ]}
+          onStepChange={handleStepChange}
+          completedSteps={undefined}
+        />
+        <div className="mt-4">
+          {currentStep === 1 && <EventInfoForm onNextStep={handleNextStep} />}
+          {currentStep === 2 && (
+            <UploadCoverForm onNextStep={handleNextStep} onPrevStep={handlePrevStep} />
+          )}
+          {currentStep === 3 && (
+            <UploadEventImageForm onNextStep={handleNextStep} onPrevStep={handlePrevStep} />
+          )}
+          {currentStep === 4 && (
+            <PlanAccordion onPrevStep={handlePrevStep} onSubmit={methods.handleSubmit(data => console.log(data))} />
+          )}
+        </div>
+      </div>
+    </FormProvider>
+  )
+}
+
+export default React.memo(CreateActivityForm)

--- a/app/create-activity/components/EventInfoForm.tsx
+++ b/app/create-activity/components/EventInfoForm.tsx
@@ -1,0 +1,363 @@
+'use client';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { FormData } from '../schema/formDataSchema';
+import FormField from '../../../components/form/FormField';
+import FormInput from '../../../components/form/FormInput';
+import FormNumberInput from '../../../components/form/FormNumberInput';
+import FormRadioGroup from '../../../components/form/FormRadioGroup';
+import FormSwitch from '../../../components/form/FormSwitch';
+import FormDynamicInputs from '../../../components/form/FormDynamicInputs';
+
+interface EventInfoFormProps {
+  /** 下一步 */
+  onNextStep: () => void;
+  /** 返回上一步 */
+  onPrevStep?: () => void;
+}
+
+function EventInfoForm({ onNextStep, onPrevStep }: EventInfoFormProps) {
+  const {
+    register,
+    getValues,
+    setValue,
+    trigger,
+    formState: { errors },
+  } = useFormContext<FormData>();
+
+  // 產生小時選項：00-23
+  const hours = Array.from({ length: 24 }, (_, i) =>
+    i.toString().padStart(2, '0')
+  );
+  // 產生分鐘選項：00, 15, 30, 45
+  const minutes = ['00', '15', '30', '45'];
+
+  // 處理下一步按鈕點擊
+  const handleNextStep = async () => {
+    // 先觸發表單驗證，僅驗證 eventInfo 欄位
+    const isValid = await trigger('eventInfo');
+
+    // 印出當前表單狀態與驗證結果
+    console.log('繼續填寫按鈕點擊，表單狀態:', {
+      表單資料: getValues(),
+      驗證結果: isValid,
+      錯誤訊息: errors,
+    });
+
+    // 如果驗證通過，才進行下一步
+    if (isValid) {
+      onNextStep();
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto bg-base-100 p-6 rounded-lg shadow-sm">
+      <h2 className="text-2xl font-bold mb-6 text-center">活動基本資訊</h2>
+
+      <div className="space-y-8">
+        {/* 基本資訊區塊 */}
+        <div className="card bg-base-200 shadow-sm">
+          <div className="card-body">
+            <h3 className="card-title text-lg mb-4">基本資訊</h3>
+
+            <div className="space-y-4">
+              {/* 活動主題 */}
+              <FormField
+                label="活動主題"
+                name="eventInfo.title"
+                required
+                error={errors.eventInfo?.title?.message}
+              >
+                <FormInput
+                  name="eventInfo.title"
+                  placeholder="請輸入活動主題（最多100字）"
+                />
+              </FormField>
+
+              {/* 主辦方名稱 */}
+              <FormField
+                label="主辦方名稱"
+                name="eventInfo.organizer"
+                required
+                error={errors.eventInfo?.organizer?.message}
+              >
+                <FormInput
+                  name="eventInfo.organizer"
+                  placeholder="請輸入主辦方名稱（最多50字）"
+                />
+              </FormField>
+
+              {/* 活動地點 */}
+              <FormField
+                label="活動地點"
+                name="eventInfo.location"
+                required
+                error={errors.eventInfo?.location?.message}
+              >
+                <FormInput
+                  name="eventInfo.location"
+                  placeholder="請輸入活動地點（最多200字）"
+                />
+              </FormField>
+
+              {/* 上限人數 */}
+              <FormField
+                label="上限人數"
+                name="eventInfo.maxParticipants"
+                required
+                error={errors.eventInfo?.maxParticipants?.message}
+              >
+                <FormNumberInput
+                  name="eventInfo.maxParticipants"
+                  min={1}
+                  max={10000}
+                  step={1}
+                />
+              </FormField>
+            </div>
+          </div>
+        </div>
+
+        {/* 活動時間區塊 */}
+        <div className="card bg-base-200 shadow-sm">
+          <div className="card-body">
+            <h3 className="card-title text-lg mb-4">活動時間</h3>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                label="開始日期"
+                name="eventInfo.startDate"
+                required
+                error={errors.eventInfo?.startDate?.message}
+              >
+                <input
+                  type="date"
+                  className="input input-bordered w-full"
+                  {...register('eventInfo.startDate')}
+                />
+              </FormField>
+
+              <FormField
+                label="開始時間"
+                name="eventInfo.startTime"
+                required
+                error={errors.eventInfo?.startTime?.message}
+              >
+                <div className="flex gap-2">
+                  <select
+                    className="select select-bordered flex-1"
+                    onChange={(e) => {
+                      const hour = e.target.value.split(':')[0];
+                      const minute =
+                        getValues('eventInfo.startTime').split(':')[1] || '00';
+                      setValue('eventInfo.startTime', `${hour}:${minute}`);
+                      trigger('eventInfo.startTime');
+                    }}
+                    defaultValue={
+                      getValues('eventInfo.startTime').split(':')[0] + ':00' ||
+                      '00:00'
+                    }
+                  >
+                    {hours.map((hour) => (
+                      <option key={`start-h-${hour}`} value={`${hour}:00`}>
+                        {hour} 時
+                      </option>
+                    ))}
+                  </select>
+                  <span className="self-center">:</span>
+                  <select
+                    className="select select-bordered flex-1"
+                    onChange={(e) => {
+                      const minute = e.target.value.split(':')[1];
+                      const hour =
+                        getValues('eventInfo.startTime').split(':')[0] || '00';
+                      setValue('eventInfo.startTime', `${hour}:${minute}`);
+                      trigger('eventInfo.startTime');
+                    }}
+                    defaultValue={
+                      '00:' +
+                      (getValues('eventInfo.startTime').split(':')[1] || '00')
+                    }
+                  >
+                    {minutes.map((minute) => (
+                      <option key={`start-m-${minute}`} value={`00:${minute}`}>
+                        {minute} 分
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </FormField>
+
+              <FormField
+                label="結束日期"
+                name="eventInfo.endDate"
+                required
+                error={errors.eventInfo?.endDate?.message}
+              >
+                <input
+                  type="date"
+                  className="input input-bordered w-full"
+                  {...register('eventInfo.endDate')}
+                />
+              </FormField>
+
+              <FormField
+                label="結束時間"
+                name="eventInfo.endTime"
+                required
+                error={errors.eventInfo?.endTime?.message}
+              >
+                <div className="flex gap-2">
+                  <select
+                    className="select select-bordered flex-1"
+                    onChange={(e) => {
+                      const hour = e.target.value.split(':')[0];
+                      const minute =
+                        getValues('eventInfo.endTime').split(':')[1] || '00';
+                      setValue('eventInfo.endTime', `${hour}:${minute}`);
+                      trigger('eventInfo.endTime');
+                    }}
+                    defaultValue={
+                      getValues('eventInfo.endTime').split(':')[0] + ':00' ||
+                      '00:00'
+                    }
+                  >
+                    {hours.map((hour) => (
+                      <option key={`end-h-${hour}`} value={`${hour}:00`}>
+                        {hour} 時
+                      </option>
+                    ))}
+                  </select>
+                  <span className="self-center">:</span>
+                  <select
+                    className="select select-bordered flex-1"
+                    onChange={(e) => {
+                      const minute = e.target.value.split(':')[1];
+                      const hour =
+                        getValues('eventInfo.endTime').split(':')[0] || '00';
+                      setValue('eventInfo.endTime', `${hour}:${minute}`);
+                      trigger('eventInfo.endTime');
+                    }}
+                    defaultValue={
+                      '00:' +
+                      (getValues('eventInfo.endTime').split(':')[1] || '00')
+                    }
+                  >
+                    {minutes.map((minute) => (
+                      <option key={`end-m-${minute}`} value={`00:${minute}`}>
+                        {minute} 分
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </FormField>
+            </div>
+          </div>
+        </div>
+
+        {/* 活動詳情區塊 */}
+        <div className="card bg-base-200 shadow-sm">
+          <div className="card-body">
+            <h3 className="card-title text-lg mb-4">活動詳情</h3>
+
+            {/* 活動描述 */}
+            <FormField
+              label="活動描述"
+              name="eventInfo.description"
+              required
+              error={errors.eventInfo?.description?.message}
+            >
+              <textarea
+                className="textarea textarea-bordered w-full"
+                rows={5}
+                placeholder="請描述您的活動內容（最多5000字）"
+                {...register('eventInfo.description')}
+              />
+            </FormField>
+
+            {/* 活動標籤 */}
+            <FormField
+              label="活動標籤"
+              name="eventInfo.tags"
+              required
+              error={errors.eventInfo?.tags?.message}
+            >
+              <div className="bg-base-100 p-3 rounded-lg">
+                <FormRadioGroup
+                  name="eventInfo.tags"
+                  options={[
+                    { value: '寵物友善', label: '寵物友善' },
+                    { value: '閤家同樂', label: '閤家同樂' },
+                    { value: '新手友善', label: '新手友善' },
+                    { value: '進階挑戰', label: '進階挑戰' },
+                    { value: '秘境探索', label: '秘境探索' },
+                    { value: '奢豪露營', label: '奢豪露營' },
+                  ]}
+                />
+              </div>
+            </FormField>
+          </div>
+        </div>
+
+        {/* 其他選項區塊 */}
+        <div className="card bg-base-200 shadow-sm">
+          <div className="card-body">
+            <h3 className="card-title text-lg mb-4">其他選項</h3>
+
+            {/* 取消政策 */}
+            <FormField
+              label="取消政策"
+              name="eventInfo.cancelPolicy"
+              error={errors.eventInfo?.cancelPolicy?.message}
+            >
+              <div className="bg-base-100 p-3 rounded-lg">
+                <FormSwitch
+                  name="eventInfo.cancelPolicy"
+                  label="15 天前可免費取消"
+                />
+              </div>
+            </FormField>
+
+            {/* 行前通知 */}
+            <FormField
+              label="行前通知（選填）"
+              name="eventInfo.notifications"
+              error={errors.eventInfo?.notifications?.message}
+            >
+              <div className="bg-base-100 p-3 rounded-lg">
+                <FormDynamicInputs
+                  addButtonLabel="新增通知"
+                  placeholder="輸入行前通知內容（至少5個字）"
+                />
+              </div>
+            </FormField>
+          </div>
+        </div>
+
+        {/* 按鈕區 */}
+        <div className="flex justify-between pt-4">
+          {onPrevStep && (
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={onPrevStep}
+            >
+              返回
+            </button>
+          )}
+          <div className={onPrevStep ? '' : 'ml-auto'}>
+            <button
+              type="button"
+              className="btn btn-primary px-8"
+              onClick={handleNextStep}
+            >
+              繼續填寫，下一步
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(EventInfoForm);

--- a/app/create-activity/components/EventStepper.tsx
+++ b/app/create-activity/components/EventStepper.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React from 'react';
+
+interface EventStepperProps {
+  /** 當前步驟 */
+  currentStep: number;
+  /** 步驟總數 */
+  totalSteps: number;
+  /** 步驟標題 */
+  stepTitles: string[];
+  /** 步驟變更事件 */
+  onStepChange: (step: number) => void;
+  /** 已完成的步驟清單 */
+  completedSteps?: number[];
+}
+
+function EventStepper({
+  currentStep,
+  stepTitles,
+  onStepChange,
+  completedSteps,
+}: EventStepperProps) {
+  // 已完成步驟清單，預設為當前步驟前的所有步驟
+  const completed =
+    completedSteps ??
+    Array.from({ length: Math.max(0, currentStep - 1) }, (_, i) => i + 1);
+
+  return (
+    <div className="overflow-x-auto">
+      <ul className="steps w-full">
+        {stepTitles.map((title, idx) => {
+          const step = idx + 1;
+          const isCompleted = completed.includes(step);
+          const isCurrent = step === currentStep;
+          const baseClass = 'step';
+          const statusClass = isCompleted
+            ? ' step-success'
+            : isCurrent
+            ? ' step-primary'
+            : '';
+          return (
+            <li
+              key={step}
+              className={baseClass + statusClass}
+              onClick={() => {
+                if (isCompleted) onStepChange(step);
+              }}
+              style={{ cursor: isCompleted ? 'pointer' : 'default' }}
+            >
+              {title}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default React.memo(EventStepper);

--- a/app/create-activity/components/PlanAccordion.tsx
+++ b/app/create-activity/components/PlanAccordion.tsx
@@ -1,0 +1,181 @@
+'use client';
+import React, { useState, useCallback } from 'react';
+import { useFormContext, useFieldArray } from 'react-hook-form';
+import { FormData } from '../schema/formDataSchema';
+import PlanAccordionItem from './PlanAccordionItem';
+
+interface PlanAccordionProps {
+  /** 返回上一部 */
+  onPrevStep: () => void;
+  /** 提交表單 */
+  onSubmit: () => void;
+}
+
+function PlanAccordion({ onPrevStep, onSubmit }: PlanAccordionProps) {
+  // 從 formContext 獲取方法
+  const {
+    control,
+    trigger,
+    formState: { errors, isSubmitting },
+  } = useFormContext<FormData>();
+
+  // 使用 useFieldArray 管理多方案
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'plans',
+  });
+
+  // 控制哪些方案面板是展開的
+  const [expandedPlans, setExpandedPlans] = useState<number[]>([0]); // 默認第一個展開
+
+  // 新增方案
+  const handleAddPlan = useCallback(() => {
+    if (fields.length >= 3) return;
+
+    // 添加新方案，使用適當的默認值
+    append({
+      title: `方案 ${fields.length + 1}`,
+      price: 0,
+      discountPrice: undefined,
+      content: [],
+      addOns: [],
+    });
+
+    // 自動展開新添加的方案
+    const newIndex = fields.length;
+    setExpandedPlans((prev) => [...prev, newIndex]);
+  }, [append, fields.length]);
+
+  // 刪除方案
+  const handleDeletePlan = useCallback(
+    (index: number) => {
+      if (fields.length <= 1) return;
+
+      // 添加確認對話框
+      if (window.confirm(`確定要刪除方案 ${index + 1} 嗎？`)) {
+        remove(index);
+
+        // 更新展開狀態
+        setExpandedPlans((prev) =>
+          prev.filter((i) => i !== index).map((i) => (i > index ? i - 1 : i))
+        );
+      }
+    },
+    [fields.length, remove]
+  );
+
+  // 切換方案面板展開/收起
+  const togglePlan = useCallback((index: number) => {
+    setExpandedPlans((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+    );
+  }, []);
+
+  // 檢查表單提交前的驗證
+  const handleSubmit = async () => {
+    const isValid = await trigger('plans');
+    if (isValid) {
+      onSubmit();
+    } else {
+      // 自動展開有錯誤的方案
+      const plansWithErrors = Object.keys(errors.plans || {})
+        .map((key) => parseInt(key))
+        .filter((index) => !isNaN(index));
+
+      if (plansWithErrors.length > 0) {
+        setExpandedPlans((prev) => [...new Set([...prev, ...plansWithErrors])]);
+      }
+    }
+  };
+
+  // 控制是否可以添加更多方案
+  const canAddMorePlan = fields.length < 3;
+
+  // 控制是否可以刪除方案
+  const canDeletePlan = fields.length > 1;
+
+  return (
+    <div className="max-w-4xl mx-auto bg-base-100 p-6 rounded-lg shadow-sm">
+      <h2 className="text-2xl font-bold mb-6 text-center">方案設計</h2>
+
+      <div className="space-y-8">
+        {/* 方案數量顯示 */}
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">
+            已建立方案 ({fields.length}/3)
+          </h3>
+          {canAddMorePlan && (
+            <button
+              type="button"
+              className="btn btn-sm btn-outline btn-primary"
+              onClick={handleAddPlan}
+            >
+              新增方案
+            </button>
+          )}
+        </div>
+
+        {/* 方案列表 */}
+        {fields.length === 0 ? (
+          <div className="text-center py-8 bg-base-200 rounded-lg">
+            <p className="text-base-content/70">尚未建立任何方案</p>
+            <button
+              type="button"
+              className="btn btn-primary mt-4"
+              onClick={handleAddPlan}
+            >
+              建立第一個方案
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {fields.map((field, index) => (
+              <PlanAccordionItem
+                key={field.id}
+                index={index}
+                isExpanded={expandedPlans.includes(index)}
+                onToggle={() => togglePlan(index)}
+                onDelete={() => handleDeletePlan(index)}
+                canDelete={canDeletePlan}
+              />
+            ))}
+
+            {/* 新增方案按鈕（在列表底部） */}
+            {canAddMorePlan && (
+              <div className="flex justify-center my-4">
+                <button
+                  type="button"
+                  className="btn btn-outline btn-primary"
+                  onClick={handleAddPlan}
+                >
+                  新增方案
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 按鈕區 */}
+        <div className="flex justify-between pt-4">
+          <button
+            type="button"
+            className="btn btn-outline"
+            onClick={onPrevStep}
+          >
+            返回上一步
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary px-8"
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '提交中...' : '提交'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(PlanAccordion);

--- a/app/create-activity/components/PlanAccordionItem.tsx
+++ b/app/create-activity/components/PlanAccordionItem.tsx
@@ -1,0 +1,300 @@
+'use client';
+import React from 'react';
+import { useFormContext, useFieldArray } from 'react-hook-form';
+import { FormData } from '../schema/formDataSchema';
+import FormField from '../../../components/form/FormField';
+import FormInput from '../../../components/form/FormInput';
+import FormNumberInput from '../../../components/form/FormNumberInput';
+
+interface PlanAccordionItemProps {
+  /** 方案索引 */
+  index: number;
+  /** 是否展開 */
+  isExpanded: boolean;
+  /** 切換展開狀態 */
+  onToggle: () => void;
+  /** 刪除方案 */
+  onDelete: () => void;
+  /** 是否可以刪除 */
+  canDelete: boolean;
+}
+
+function PlanAccordionItem({
+  index,
+  isExpanded,
+  onToggle,
+  onDelete,
+  canDelete,
+}: PlanAccordionItemProps) {
+  const {
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext<FormData>();
+
+  // 監聽方案標題，用於顯示在摺疊面板標題上
+  const planTitle = watch(`plans.${index}.title`) || `方案 ${index + 1}`;
+
+  // 設置方案內容的 useFieldArray
+  const contentArray = useFieldArray({
+    control,
+    name: `plans.${index}.content`,
+  });
+
+  // 設置加購商品的 useFieldArray
+  const addOnsArray = useFieldArray({
+    control,
+    name: `plans.${index}.addOns`,
+  });
+
+  // 方案錯誤訊息
+  const planErrors = errors.plans?.[index];
+
+  // 添加內容項
+  const handleAddContent = () => {
+    contentArray.append({ value: '' });
+  };
+
+  // 添加加購商品
+  const handleAddAddOn = () => {
+    addOnsArray.append({ name: '', price: 0 });
+  };
+
+  return (
+    <div
+      className={`collapse ${
+        isExpanded ? 'collapse-open' : 'collapse-close'
+      } bg-base-200 rounded-lg`}
+    >
+      <div
+        className="collapse-title text-xl font-medium flex justify-between items-center cursor-pointer"
+        onClick={onToggle}
+      >
+        <div>
+          方案 {index + 1}:
+          <span className="ml-2 font-normal text-base">{planTitle}</span>
+        </div>
+        <div className="flex items-center">
+          {planErrors && (
+            <span className="text-error text-sm mr-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </span>
+          )}
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d={isExpanded ? 'M19 9l-7 7-7-7' : 'M9 5l7 7-7 7'}
+            />
+          </svg>
+        </div>
+      </div>
+      <div className="collapse-content">
+        <div className="p-4 space-y-6">
+          {/* 方案基本資訊 */}
+          <div className="card bg-base-100 shadow-sm">
+            <div className="card-body">
+              <h3 className="card-title text-lg mb-4">方案基本資訊</h3>
+
+              <div className="space-y-4">
+                {/* 方案標題 */}
+                <FormField
+                  label="方案標題"
+                  name={`plans.${index}.title`}
+                  required
+                  error={planErrors?.title?.message}
+                >
+                  <FormInput
+                    name={`plans.${index}.title`}
+                    placeholder="請輸入方案標題（最多100字）"
+                  />
+                </FormField>
+
+                {/* 方案價格 */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <FormField
+                    label="方案價格"
+                    name={`plans.${index}.price`}
+                    required
+                    error={planErrors?.price?.message}
+                  >
+                    <FormNumberInput
+                      name={`plans.${index}.price`}
+                      min={0}
+                      step={1}
+                    />
+                  </FormField>
+
+                  {/* 折扣價格 */}
+                  <FormField
+                    label="折扣價格（可選）"
+                    name={`plans.${index}.discountPrice`}
+                    error={planErrors?.discountPrice?.message}
+                  >
+                    <FormNumberInput
+                      name={`plans.${index}.discountPrice`}
+                      min={0}
+                      step={1}
+                    />
+                  </FormField>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 方案內容 */}
+          <div className="card bg-base-100 shadow-sm">
+            <div className="card-body">
+              <h3 className="card-title text-lg mb-4">方案內容</h3>
+
+              <FormField
+                label="內容項目"
+                name={`plans.${index}.content`}
+                required
+                error={planErrors?.content?.message}
+              >
+                <div className="space-y-2">
+                  {contentArray.fields.map((field, contentIndex) => (
+                    <div key={field.id} className="flex items-center gap-2">
+                      <FormInput
+                        name={`plans.${index}.content.${contentIndex}.value`}
+                        placeholder="請輸入內容項目"
+                      />
+                      <button
+                        type="button"
+                        className="btn btn-square btn-sm btn-outline btn-error"
+                        onClick={() => contentArray.remove(contentIndex)}
+                        disabled={contentArray.fields.length <= 1}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-5 w-5"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline btn-primary w-full"
+                    onClick={handleAddContent}
+                  >
+                    + 新增內容項目
+                  </button>
+                </div>
+              </FormField>
+            </div>
+          </div>
+
+          {/* 加購商品 */}
+          <div className="card bg-base-100 shadow-sm">
+            <div className="card-body">
+              <h3 className="card-title text-lg mb-4">加購商品（可選）</h3>
+
+              <FormField
+                label="加購商品"
+                name={`plans.${index}.addOns`}
+                error={planErrors?.addOns?.message}
+              >
+                <div className="space-y-4">
+                  {addOnsArray.fields.length === 0 ? (
+                    <div className="text-center py-4 bg-base-200 rounded-lg text-base-content/70">
+                      尚未添加加購商品
+                    </div>
+                  ) : (
+                    addOnsArray.fields.map((field, addOnIndex) => (
+                      <div
+                        key={field.id}
+                        className="grid grid-cols-1 md:grid-cols-3 gap-2 items-center p-2 border rounded-md"
+                      >
+                        <div className="md:col-span-2">
+                          <FormInput
+                            name={`plans.${index}.addOns.${addOnIndex}.name`}
+                            placeholder="商品名稱"
+                          />
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <FormNumberInput
+                            name={`plans.${index}.addOns.${addOnIndex}.price`}
+                            min={0}
+                            step={1}
+                          />
+                          <button
+                            type="button"
+                            className="btn btn-square btn-sm btn-outline btn-error"
+                            onClick={() => addOnsArray.remove(addOnIndex)}
+                          >
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-5 w-5"
+                              viewBox="0 0 20 20"
+                              fill="currentColor"
+                            >
+                              <path
+                                fillRule="evenodd"
+                                d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                                clipRule="evenodd"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline btn-primary w-full"
+                    onClick={handleAddAddOn}
+                  >
+                    + 新增加購商品
+                  </button>
+                </div>
+              </FormField>
+            </div>
+          </div>
+
+          {/* 方案操作按鈕 */}
+          <div className="flex justify-end mt-4">
+            {canDelete && (
+              <button
+                type="button"
+                className="btn btn-error btn-sm"
+                onClick={onDelete}
+              >
+                刪除方案
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(PlanAccordionItem);

--- a/app/create-activity/components/UploadCoverForm.tsx
+++ b/app/create-activity/components/UploadCoverForm.tsx
@@ -1,0 +1,142 @@
+'use client';
+import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { FormData } from '../schema/formDataSchema';
+import FileUploader from '../../../components/form/FileUploader';
+import ImagePreview from '../../../components/form/ImagePreview';
+import FormField from '../../../components/form/FormField';
+
+interface UploadCoverFormProps {
+  /** 下一步 */
+  onNextStep: () => void;
+  /** 返回上一步 */
+  onPrevStep: () => void;
+}
+
+function UploadCoverForm({ onNextStep, onPrevStep }: UploadCoverFormProps) {
+  const {
+    setValue,
+    getValues,
+    trigger,
+    formState: { errors },
+  } = useFormContext<FormData>();
+
+  // 本地狀態管理上傳的檔案
+  const [coverFiles, setCoverFiles] = useState<File[]>(() => {
+    // 從表單中獲取已有圖片資料
+    const existingFiles = getValues('coverImages') || [];
+
+    // 檢查是否有現有的檔案資料
+    if (existingFiles.length > 0) {
+      console.log('取得現有的圖片檔案：', existingFiles);
+      return existingFiles as File[];
+    }
+
+    // 若沒有現有檔案則返回空陣列
+    return [];
+  });
+
+  // 處理檔案選擇
+  const handleFileSelect = (file: File) => {
+    if (coverFiles.length >= 3) {
+      return; // 已達到最大上限
+    }
+
+    const newFiles = [...coverFiles, file];
+    setCoverFiles(newFiles);
+    setValue('coverImages', newFiles);
+    trigger('coverImages'); // 觸發驗證
+  };
+
+  // 處理刪除圖片
+  const handleDeleteImage = (index: number) => {
+    const newFiles = [...coverFiles];
+    newFiles.splice(index, 1);
+    setCoverFiles(newFiles);
+    setValue('coverImages', newFiles);
+    trigger('coverImages'); // 觸發驗證
+  };
+
+  // 處理下一步按鈕點擊
+  const handleNextStep = async () => {
+    // 先觸發驗證
+    const isValid = await trigger('coverImages');
+    if (isValid) {
+      onNextStep();
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto bg-base-100 p-6 rounded-lg shadow-sm">
+      <h2 className="text-2xl font-bold mb-6 text-center">上傳活動封面</h2>
+
+      <div className="space-y-8">
+        <FormField
+          label="封面圖片"
+          name="coverImages"
+          required
+          error={errors.coverImages?.message as string}
+        >
+          <div className="space-y-4">
+            {/* 上傳區域（僅在少於3張圖片時顯示） */}
+            {coverFiles.length < 3 && (
+              <div className="mb-6">
+                <FileUploader
+                  accept="image/jpeg, image/png, image/webp"
+                  maxSize={4 * 1024 * 1024} // 4MB
+                  onFileSelect={handleFileSelect}
+                  error={errors.coverImages?.message as string}
+                />
+              </div>
+            )}
+
+            {/* 上傳提示 */}
+            <div className="text-sm text-base-content/70 mb-6">
+              <p>最多新增3張活動封面，至少需要上傳1張</p>
+              <p>建議尺寸：1080 x 540 pixel，格式：JPEG、PNG、WebP</p>
+            </div>
+
+            {/* 已上傳圖片預覽 */}
+            {coverFiles.length > 0 && (
+              <div>
+                <h3 className="text-lg font-medium mb-3">已上傳的封面圖片</h3>
+                <div className="flex flex-wrap gap-4">
+                  {coverFiles.map((file, index) => (
+                    <ImagePreview
+                      key={index}
+                      src={file}
+                      alt={`活動封面 ${index + 1}`}
+                      width={240}
+                      height={120}
+                      onDelete={() => handleDeleteImage(index)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </FormField>
+
+        {/* 按鈕區 */}
+        <div className="flex justify-between pt-4">
+          <button
+            type="button"
+            className="btn btn-outline"
+            onClick={onPrevStep}
+          >
+            返回
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary px-8"
+            onClick={handleNextStep}
+          >
+            繼續填寫，下一步
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(UploadCoverForm);

--- a/app/create-activity/components/UploadEventImageForm.tsx
+++ b/app/create-activity/components/UploadEventImageForm.tsx
@@ -1,0 +1,185 @@
+'use client';
+import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { FormData } from '../schema/formDataSchema';
+import FileUploader from '../../../components/form/FileUploader';
+import ImagePreview from '../../../components/form/ImagePreview';
+import FormField from '../../../components/form/FormField';
+
+// 活動圖片類型定義
+interface EventImage {
+  /** 圖片檔案 */
+  file: File;
+  /** 圖片描述 */
+  description: string;
+}
+
+interface UploadEventImageFormProps {
+  /** 下一步 */
+  onNextStep: () => void;
+  /** 返回上一步 */
+  onPrevStep: () => void;
+}
+
+function UploadEventImageForm({
+  onNextStep,
+  onPrevStep,
+}: UploadEventImageFormProps) {
+  const {
+    setValue,
+    getValues,
+    trigger,
+    formState: { errors },
+  } = useFormContext<FormData>();
+
+  // 本地狀態管理上傳的檔案
+  const [eventImages, setEventImages] = useState<EventImage[]>(() => {
+    // 從表單中獲取已有圖片資料
+    const existingFiles = getValues('eventImages') || [];
+
+    // 檢查是否有現有的檔案資料
+    if (existingFiles.length > 0) {
+      console.log('取得現有的活動圖片檔案：', existingFiles);
+      return existingFiles.map((item) => ({
+        file: item.file as File,
+        description: item.description || '',
+      }));
+    }
+
+    // 若沒有現有檔案則返回空陣列
+    return [];
+  });
+
+  // 處理檔案選擇
+  const handleFileSelect = (file: File) => {
+    const newImage: EventImage = {
+      file,
+      description: '',
+    };
+    const updatedImages = [...eventImages, newImage];
+    setEventImages(updatedImages);
+    setValue('eventImages', updatedImages, { shouldValidate: true });
+  };
+
+  // 處理刪除圖片
+  const handleDeleteImage = (index: number) => {
+    const updatedImages = eventImages.filter((_, i) => i !== index);
+    setEventImages(updatedImages);
+    setValue('eventImages', updatedImages, { shouldValidate: true });
+  };
+
+  // 處理圖片描述更新
+  const handleDescriptionChange = (index: number, value: string) => {
+    const updatedImages = [...eventImages];
+    updatedImages[index].description = value;
+    setEventImages(updatedImages);
+    setValue('eventImages', updatedImages, { shouldValidate: true });
+  };
+
+  // 處理下一步按鈕點擊
+  const handleNextStep = async () => {
+    const isValid = await trigger('eventImages');
+    if (isValid) {
+      onNextStep();
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto bg-base-100 p-6 rounded-lg shadow-sm">
+      <h2 className="text-2xl font-bold mb-6 text-center">上傳活動圖片</h2>
+
+      <div className="space-y-8">
+        <FormField
+          label="活動圖片"
+          name="eventImages"
+          error={errors.eventImages?.message as string}
+        >
+          <div className="space-y-4">
+            {/* 上傳區域 */}
+            <div className="mb-6">
+              <FileUploader
+                accept="image/jpeg, image/png, image/webp"
+                maxSize={4 * 1024 * 1024} // 4MB
+                onFileSelect={handleFileSelect}
+                error={errors.eventImages?.message as string}
+              />
+            </div>
+
+            {/* 上傳提示 */}
+            <div className="text-sm text-base-content/70 mb-6">
+              <p>上傳活動相關圖片，展示活動場地或過往活動照片</p>
+              <p>建議尺寸：1080 x 540 pixel，格式：JPEG、PNG、WebP</p>
+            </div>
+
+            {/* 已上傳圖片預覽 */}
+            {eventImages.length > 0 && (
+              <div>
+                <h3 className="text-lg font-medium mb-3">
+                  已上傳的活動圖片 ({eventImages.length} 張)
+                </h3>
+                <div className="flex flex-col gap-6">
+                  {eventImages.map((image, index) => (
+                    <div key={index} className="border rounded-lg p-4">
+                      <div className="flex items-start gap-4">
+                        <div className="w-60 shrink-0">
+                          <ImagePreview
+                            src={image.file}
+                            alt={`活動圖片 ${index + 1}`}
+                            width={240}
+                            height={120}
+                            onDelete={() => handleDeleteImage(index)}
+                          />
+                        </div>
+                        <div className="flex-1">
+                          <div className="form-control w-full">
+                            <label className="label">
+                              <span className="label-text">
+                                圖片描述 (選填，最多100字)
+                              </span>
+                              <span className="label-text-alt">
+                                {image.description.length}/100
+                              </span>
+                            </label>
+                            <textarea
+                              className="textarea textarea-bordered w-full"
+                              placeholder="請輸入圖片描述..."
+                              maxLength={100}
+                              value={image.description}
+                              onChange={(e) =>
+                                handleDescriptionChange(index, e.target.value)
+                              }
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </FormField>
+
+        {/* 按鈕區 */}
+        <div className="flex justify-between pt-4">
+          <button
+            type="button"
+            className="btn btn-outline"
+            onClick={onPrevStep}
+          >
+            返回
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary px-8"
+            onClick={handleNextStep}
+          >
+            繼續填寫，下一步
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(UploadEventImageForm);

--- a/app/create-activity/page.tsx
+++ b/app/create-activity/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import CreateActivityForm from './components/CreateActivityForm';
+
+function CreateActivityPage() {
+  return <CreateActivityForm />;
+}
+
+export default CreateActivityPage;

--- a/app/create-activity/schema/formDataSchema.ts
+++ b/app/create-activity/schema/formDataSchema.ts
@@ -1,0 +1,108 @@
+import * as z from 'zod';
+
+// Step1: 活動基本資訊
+export const EventInfoSchema = z
+  .object({
+    title: z.string().min(1, '請輸入活動主題').max(100, '最多100字'),
+    organizer: z.string().min(1, '請輸入主辦方名稱').max(50, '最多50字'),
+    location: z.string().min(1, '請輸入活動地點').max(200, '最多200字'),
+    startDate: z
+      .string()
+      .refine((val) => /^\d{4}-\d{2}-\d{2}$/.test(val), '格式需為YYYY-MM-DD'),
+    startTime: z
+      .string()
+      .refine((val) => /^\d{2}:\d{2}$/.test(val), '格式需為HH:mm'),
+    endDate: z
+      .string()
+      .refine((val) => /^\d{4}-\d{2}-\d{2}$/.test(val), '格式需為YYYY-MM-DD'),
+    endTime: z
+      .string()
+      .refine((val) => /^\d{2}:\d{2}$/.test(val), '格式需為HH:mm'),
+    maxParticipants: z.number().min(1, '至少1人').max(10000, '最多10000人'),
+    description: z.string().min(1, '請輸入活動描述').max(5000, '最多5000字'),
+    tags: z.enum([
+      '寵物友善',
+      '閤家同樂',
+      '新手友善',
+      '進階挑戰',
+      '秘境探索',
+      '奢豪露營',
+    ]),
+    cancelPolicy: z.boolean(),
+    notifications: z.array(z.string().min(5, '至少5字')).optional(),
+  })
+  .refine((data) => data.endDate >= data.startDate, {
+    message: '結束日期不可早於開始日期',
+    path: ['endDate'],
+  });
+
+// 圖片檔案驗證
+const fileSchema = z
+  .object({
+    type: z.string(),
+    size: z.number(),
+  })
+  .refine(
+    (file) => ['image/jpeg', 'image/png', 'image/webp'].includes(file.type),
+    {
+      message: '僅接受 JPEG、PNG、WebP 格式',
+    }
+  )
+  .refine((file) => file.size <= 4 * 1024 * 1024, {
+    message: '檔案大小須小於4MB',
+  });
+
+// Step2: 封面圖片
+export const CoverImageSchema = z
+  .array(fileSchema)
+  .min(1, '至少上傳1張封面圖片')
+  .max(3, '最多3張封面圖片');
+
+// Step3: 活動內容圖片
+export const EventImageSchema = z.object({
+  file: fileSchema,
+  description: z.string().max(100, '最多100字').optional(),
+});
+
+export const EventImagesSchema = z.array(EventImageSchema).optional();
+
+// Step4: 活動方案
+const ContentSchema = z.object({
+  value: z.string().min(1, '請輸入內容').max(500, '最多500字'),
+})
+
+const AddOnSchema = z.object({
+  name: z.string().min(1, '請輸入商品名稱'),
+  price: z.number().min(0, '價格不可為負'),
+});
+
+const PlanSchema = z
+  .object({
+    title: z.string().min(1, '請輸入方案標題').max(100, '最多100字'),
+    price: z.number().min(0, '價格不可為負'),
+    discountPrice: z.number().min(0, '價格不可為負').optional(),
+    content: z.array(ContentSchema).optional(),
+    addOns: z.array(AddOnSchema).optional(),
+  })
+  .refine(
+    (data) =>
+      data.discountPrice === undefined || data.discountPrice <= data.price,
+    {
+      message: '折扣價不可大於原價',
+      path: ['discountPrice'],
+    }
+  );
+export const PlanArraySchema = z
+  .array(PlanSchema)
+  .min(1, '請至少一個方案')
+  .max(3, '最多3個方案');
+
+// 最終整合
+export const FormDataSchema = z.object({
+  eventInfo: EventInfoSchema,
+  coverImages: CoverImageSchema,
+  eventImages: EventImagesSchema,
+  plans: PlanArraySchema,
+});
+
+export type FormData = z.infer<typeof FormDataSchema>;

--- a/components/form/FileUploader.tsx
+++ b/components/form/FileUploader.tsx
@@ -1,0 +1,122 @@
+'use client';
+import React, { useRef, useState } from 'react';
+import Image from 'next/image';
+
+interface FileUploaderProps {
+  /** 可接受檔案類型 */
+  accept?: string;
+  /** 最大檔案大小 */
+  maxSize?: number;
+  /** 檔案選擇回調函式 */
+  onFileSelect: (file: File) => void;
+  /** 錯誤訊息 */
+  error?: string;
+}
+
+function FileUploader({
+  accept = 'image/jpeg, image/png, image/webp',
+  maxSize = 4 * 1024 * 1024, // 4MB
+  onFileSelect,
+  error,
+}: FileUploaderProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragActive, setDragActive] = useState<boolean>(false);
+  const [internalError, setInternalError] = useState<string>('');
+
+  // 觸發檔案選擇對話框
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  // 處理檔案選擇
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+
+    if (files && files.length > 0) {
+      validateAndProcessFile(files[0]);
+    }
+  };
+
+  // 處理拖放
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.type === 'dragenter' || e.type === 'dragover') {
+      setDragActive(true);
+    } else if (e.type === 'dragleave') {
+      setDragActive(false);
+    }
+  };
+
+  // 處理檔案拖放
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      validateAndProcessFile(e.dataTransfer.files[0]);
+    }
+  };
+
+  // 驗證和處理檔案
+  const validateAndProcessFile = (file: File) => {
+    setInternalError('');
+
+    // 驗證檔案類型
+    if (!file.type.match(/(image\/jpeg|image\/png|image\/webp)/)) {
+      setInternalError('請上傳 JPEG、PNG 或 WebP 格式的圖片');
+      return;
+    }
+
+    // 驗證檔案大小
+    if (file.size > maxSize) {
+      setInternalError(
+        `檔案大小超過 ${maxSize / (1024 * 1024)}MB 限制，請重新選擇`
+      );
+      return;
+    }
+
+    // 通過驗證，呼叫回調函式
+    onFileSelect(file);
+  };
+
+  return (
+    <div className="w-full">
+      <div
+        className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer hover:bg-base-200 transition-colors ${
+          dragActive ? 'border-primary bg-base-200' : 'border-base-300'
+        } ${error || internalError ? 'border-error' : ''}`}
+        onClick={handleClick}
+        onDragEnter={handleDrag}
+        onDragOver={handleDrag}
+        onDragLeave={handleDrag}
+        onDrop={handleDrop}
+      >
+        <div className="flex flex-col items-center justify-center">
+          <div className="mb-2">
+            <Image src="/file.svg" alt="上傳圖示" width={48} height={48} />
+          </div>
+          <p className="font-medium">點擊或拖放圖片至此處上傳</p>
+          <p className="text-sm mt-1 text-base-content/70">
+            選一張好看的活動封面上傳 (1080 x 540 pixel 且小於4MB)
+          </p>
+          <p className="text-xs mt-1 text-base-content/70">
+            支援 JPEG、PNG、WebP 格式
+          </p>
+        </div>
+
+        <input
+          type="file"
+          className="hidden"
+          ref={fileInputRef}
+          accept={accept}
+          onChange={handleFileChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(FileUploader);

--- a/components/form/FormDynamicInputs.tsx
+++ b/components/form/FormDynamicInputs.tsx
@@ -1,0 +1,88 @@
+'use client';
+import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { FormData } from '../../app/create-activity/schema/formDataSchema';
+
+interface FormDynamicInputsProps {
+  /** 新增按鈕顯示文字 */
+  addButtonLabel: string;
+  /** 輸入欄位提示文字 */
+  placeholder?: string;
+}
+
+function FormDynamicInputs({
+  addButtonLabel,
+  placeholder,
+}: FormDynamicInputsProps) {
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+    trigger,
+  } = useFormContext<FormData>();
+  const notifications = watch('eventInfo.notifications') || [];
+  const [key, setKey] = useState(0); // 用於強制重新渲染
+
+  // 新增通知項目
+  const handleAddNotification = () => {
+    setValue('eventInfo.notifications', [...notifications, '']);
+    setKey((prev) => prev + 1);
+  };
+
+  // 刪除通知項目
+  const handleRemoveNotification = (index: number) => {
+    const newNotifications = [...notifications];
+    newNotifications.splice(index, 1);
+    setValue('eventInfo.notifications', newNotifications);
+    setKey((prev) => prev + 1);
+  };
+
+  // 在輸入後立即驗證
+  const handleBlur = () => {
+    trigger('eventInfo.notifications');
+  };
+
+  return (
+    <div className="space-y-2" key={key}>
+      {notifications.map((_, index) => (
+        <div key={index} className="flex items-center space-x-2 mb-2">
+          <input
+            type="text"
+            {...register(`eventInfo.notifications.${index}`, {
+              onChange: () => handleBlur(), // 輸入變更時立即驗證
+              onBlur: () => handleBlur(), // 失去焦點時立即驗證
+            })}
+            placeholder={placeholder}
+            className={`input input-bordered flex-1 ${
+              errors.eventInfo?.notifications?.[index] ? 'input-error' : ''
+            }`}
+          />
+          <button
+            type="button"
+            onClick={() => handleRemoveNotification(index)}
+            className="btn btn-error"
+            aria-label="刪除項目"
+          >
+            刪除
+          </button>
+        </div>
+      ))}
+      {/* 顯示在欄位下方的錯誤訊息 */}
+      {errors.eventInfo?.notifications && (
+        <p className="text-error mt-1">
+          {errors.eventInfo?.notifications.message || '每個通知至少需要5個字'}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={handleAddNotification}
+        className="btn btn-outline mt-2"
+      >
+        {addButtonLabel}
+      </button>
+    </div>
+  );
+}
+
+export default React.memo(FormDynamicInputs);

--- a/components/form/FormField.tsx
+++ b/components/form/FormField.tsx
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+
+interface FormFieldProps {
+  /** 標題 */
+  label: string;
+  /** 欄位名稱 */
+  name: string;
+  /** 是否為必填 */
+  required?: boolean;
+  /** 錯誤訊息 */
+  error?: string;
+  /** 子元素 */
+  children: React.ReactNode;
+}
+
+function FormField({ label, name, required, error, children }: FormFieldProps) {
+  return (
+    <div className="form-control">
+      <label htmlFor={name} className="label">
+        <span className="label-text">
+          {label}
+          {required ? ' *' : ''}
+        </span>
+      </label>
+      {children}
+      {error && <p className="text-error mt-1">{error}</p>}
+    </div>
+  );
+}
+
+export default React.memo(FormField);

--- a/components/form/FormInput.tsx
+++ b/components/form/FormInput.tsx
@@ -1,0 +1,38 @@
+'use client';
+import React from 'react';
+import { useFormContext, FieldPath, RegisterOptions } from 'react-hook-form';
+import { FormData } from '../../app/create-activity/schema/formDataSchema';
+
+interface FormInputProps {
+  /** 欄位 id */
+  name: FieldPath<FormData>;
+  /** placeholder */
+  placeholder?: string;
+  /** 欄位類型 */
+  type?: React.HTMLInputTypeAttribute;
+  /** 驗證規則 */
+  validation?: Omit<
+    RegisterOptions<FormData, FieldPath<FormData>>,
+    'valueAsNumber' | 'valueAsDate'
+  >;
+}
+
+function FormInput({
+  name,
+  placeholder,
+  type = 'text',
+  validation,
+}: FormInputProps) {
+  const { register } = useFormContext<FormData>();
+  return (
+    <input
+      id={name}
+      type={type}
+      placeholder={placeholder}
+      className="input input-bordered"
+      {...register(name, validation)}
+    />
+  );
+}
+
+export default React.memo(FormInput);

--- a/components/form/FormNumberInput.tsx
+++ b/components/form/FormNumberInput.tsx
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+import { useFormContext, FieldPath } from 'react-hook-form';
+import { FormData } from '../../app/create-activity/schema/formDataSchema';
+
+interface FormNumberInputProps {
+  /** 欄位 id */
+  name: FieldPath<FormData>;
+  /** 最小值 */
+  min?: number;
+  /** 最大值 */
+  max?: number;
+  /** 步進值 */
+  step?: number;
+}
+
+function FormNumberInput({ name, min, max, step }: FormNumberInputProps) {
+  const { register } = useFormContext<FormData>();
+  return (
+    <input
+      id={name}
+      type="number"
+      className="input input-bordered"
+      {...register(name, { valueAsNumber: true })}
+      min={min}
+      max={max}
+      step={step}
+    />
+  );
+}
+
+export default React.memo(FormNumberInput);

--- a/components/form/FormRadioGroup.tsx
+++ b/components/form/FormRadioGroup.tsx
@@ -1,0 +1,35 @@
+'use client';
+import React from 'react';
+import { useFormContext, FieldPath } from 'react-hook-form';
+import { FormData } from '../../app/create-activity/schema/formDataSchema';
+
+interface FormRadioGroupProps {
+  /** 欄位 id */
+  name: FieldPath<FormData>;
+  /** 選項清單 */
+  options: { value: string; label: string }[];
+}
+
+function FormRadioGroup({ name, options }: FormRadioGroupProps) {
+  const { register } = useFormContext<FormData>();
+  return (
+    <div className="flex space-x-4">
+      {options.map((opt) => (
+        <label
+          key={opt.value}
+          className="label cursor-pointer flex items-center"
+        >
+          <input
+            type="radio"
+            value={opt.value}
+            {...register(name)}
+            className="radio"
+          />
+          <span className="label-text ml-2">{opt.label}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export default React.memo(FormRadioGroup);

--- a/components/form/FormSelect.tsx
+++ b/components/form/FormSelect.tsx
@@ -1,0 +1,36 @@
+'use client';
+import React from 'react';
+import { useFormContext, FieldPath } from 'react-hook-form';
+import { FormData } from '../../app/create-activity/schema/formDataSchema';
+
+interface Option {
+  /** 值 */
+  value: string;
+  /** 顯示文字 */
+  label: string;
+}
+
+interface FormSelectProps {
+  /** 欄位 id */
+  name: FieldPath<FormData>;
+  /** 選項清單 */
+  options: Option[];
+  /** placeholder */
+  placeholder?: string;
+}
+
+function FormSelect({ name, options, placeholder }: FormSelectProps) {
+  const { register } = useFormContext<FormData>();
+  return (
+    <select id={name} className="select select-bordered" {...register(name)}>
+      {placeholder && <option value="">{placeholder}</option>}
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export default React.memo(FormSelect);

--- a/components/form/FormSwitch.tsx
+++ b/components/form/FormSwitch.tsx
@@ -1,0 +1,23 @@
+'use client';
+import React from 'react';
+import { useFormContext, FieldPath } from 'react-hook-form';
+import { FormData } from '../../app/create-activity/schema/formDataSchema';
+
+interface FormSwitchProps {
+  /** 欄位 id */
+  name: FieldPath<FormData>;
+  /** 標籤文字 */
+  label: string;
+}
+
+function FormSwitch({ name, label }: FormSwitchProps) {
+  const { register } = useFormContext<FormData>();
+  return (
+    <label className="label cursor-pointer flex justify-start items-center gap-2">
+      <input type="checkbox" className="toggle" {...register(name)} />
+      <span className="label-text">{label}</span>
+    </label>
+  );
+}
+
+export default React.memo(FormSwitch);

--- a/components/form/ImagePreview.tsx
+++ b/components/form/ImagePreview.tsx
@@ -1,0 +1,112 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Resizer from 'react-image-file-resizer';
+
+interface ImagePreviewProps {
+  /** 圖片來源 */
+  src: File | string;
+  /** 圖片 alt 屬性 */
+  alt: string;
+  /** 圖片寬度 */
+  width?: number;
+  /** 圖片高度 */
+  height?: number;
+  /** 刪除圖片的回調函式 */
+  onDelete: () => void;
+}
+
+function ImagePreview({
+  src,
+  alt,
+  width = 240,
+  height = 120,
+  onDelete,
+}: ImagePreviewProps) {
+  const [preview, setPreview] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    // 處理圖片預覽
+    if (!src) return;
+
+    setIsLoading(true);
+
+    // 若 src 是檔案，處理成 base64 字串
+    if (src instanceof File) {
+      try {
+        Resizer.imageFileResizer(
+          src,
+          width * 2, // 加大解析度以獲取更清晰的預覽
+          height * 2,
+          'JPEG',
+          90,
+          0,
+          (uri) => {
+            setPreview(uri as string);
+            setIsLoading(false);
+          },
+          'base64'
+        );
+      } catch (error) {
+        console.error('圖片處理失敗:', error);
+        setIsLoading(false);
+      }
+    } else {
+      // 若 src 是字串，直接使用
+      setPreview(src);
+      setIsLoading(false);
+    }
+  }, [src, width, height]);
+
+  return (
+    <div className="relative group">
+      {/* 圖片載入中顯示 */}
+      {isLoading && (
+        <div
+          className="w-full h-full flex items-center justify-center bg-base-200 rounded-lg"
+          style={{ width, height }}
+        >
+          <div className="loading loading-spinner text-primary"></div>
+        </div>
+      )}
+
+      {/* 圖片預覽 */}
+      {!isLoading && preview && (
+        <>
+          <div
+            className="relative overflow-hidden rounded-lg"
+            style={{ width, height }}
+          >
+            <Image src={preview} alt={alt} fill className="object-cover" />
+          </div>
+
+          {/* 刪除按鈕 */}
+          <button
+            type="button"
+            onClick={onDelete}
+            className="absolute -top-2 -right-2 bg-error hover:bg-error-focus text-white rounded-full w-6 h-6 flex items-center justify-center shadow-md opacity-80 hover:opacity-100 transition-opacity"
+            aria-label="刪除圖片"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default React.memo(ImagePreview);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.55.0",
         "react-hot-toast": "^2.5.2",
+        "react-image-file-resizer": "^0.4.8",
         "swr": "^2.3.3",
         "zod": "^3.24.3"
       },
@@ -4959,6 +4960,11 @@
         "react": ">=16",
         "react-dom": ">=16"
       }
+    },
+    "node_modules/react-image-file-resizer": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz",
+      "integrity": "sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-hook-form": "^7.55.0",
     "react-hot-toast": "^2.5.2",
     "swr": "^2.3.3",
+    "react-image-file-resizer": "^0.4.8",
     "zod": "^3.24.3"
   },
   "devDependencies": {


### PR DESCRIPTION
新增 PlanAccordionItem 組件，用於管理具有動態內容和附加選項的活動計劃。
創建 UploadCoverForm 組件，用於上傳封面圖片並進行驗證。
實作 UploadEventImageForm 組件，用於上傳活動圖片及其描述。
建立 CreateActivityPage 以渲染主要的活動創建表單。
使用 Zod 定義表單數據架構，用於驗證活動詳情、封面圖片、活動圖片和計劃。
引入可重用的表單組件：FileUploader、FormField、FormInput、FormNumberInput、FormRadioGroup、FormSelect、FormSwitch 和 ImagePreview，以確保一致的 UI 和功能。 增強表單中通知的動態輸入處理。