### PR TITLE
功能：創建活動主辦方彈窗

### DIFF
--- a/app/api/host/profile/avatar/route.ts
+++ b/app/api/host/profile/avatar/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import axiosInstance from "@/api/axiosIntance";
+import type { ErrorResponse } from "@/types/api/response";
+import { formatAxiosError } from "@/utils/errors";
+import { UploadImageResponse } from "@/types/api/host";
+
+// 處理主辦單位頭像上傳請求
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<UploadImageResponse | ErrorResponse>> {
+  try {
+    // 檢查用戶是否已登入
+    const accessToken = request.headers.get('access_token');
+    if (!accessToken) {
+      return NextResponse.json(
+        { status: "failed", message: "請先登入會員" },
+        { status: 401 }
+      );
+    }
+
+    // 獲取上傳的檔案
+    const formData = await request.formData();
+    const avatar = formData.get('avatar');
+    
+    // 驗證是否有檔案
+    if (!avatar || !(avatar instanceof File)) {
+      return NextResponse.json(
+        { status: "failed", message: "請選擇要上傳的圖片" },
+        { status: 400 }
+      );
+    }
+
+    // 檢查檔案大小
+    const sizeMB = avatar.size / (1024 * 1024);
+    if (sizeMB > 2) {
+      return NextResponse.json(
+        { status: "failed", message: "檔案太大，請選擇小於 2 MB 的圖片" },
+        { status: 400 }
+      );
+    }
+
+    // 檢查檔案類型
+    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+    if (!allowedTypes.includes(avatar.type)) {
+      return NextResponse.json(
+        { status: "failed", message: "只支援 JPEG、JPG、PNG 格式的圖片" },
+        { status: 400 }
+      );
+    }
+
+    try {
+      // 準備傳送到後端的 FormData
+      const apiFormData = new FormData();
+      apiFormData.append('avatar', avatar);
+
+      // 調用 API 上傳檔案
+      const response = await axiosInstance.post<UploadImageResponse>(
+        "/host/profile/avatar", 
+        apiFormData, 
+        {
+          headers: {
+            Cookie: `access_token=${accessToken}`,
+            'Content-Type': 'multipart/form-data',
+          },
+          withCredentials: true,
+        }
+      );
+
+      // 返回成功回應
+      return NextResponse.json(response.data);
+    } catch (error: unknown) {
+      // 處理 Axios 錯誤
+      const apiErr = formatAxiosError(error);
+      
+      if (apiErr.httpCode === 404) {
+        return NextResponse.json(
+          { status: "failed", message: "尚未建立主辦方資料" },
+          { status: 404 }
+        );
+      } else {
+        return NextResponse.json(
+          { status: apiErr.status, message: apiErr.message },
+          { status: apiErr.httpCode }
+        );
+      }
+    }
+  } catch (error) {
+    console.error("處理主辦單位頭像上傳時發生錯誤:", error);
+    return NextResponse.json(
+      { status: "error", message: "伺服器錯誤，無法上傳主辦方頭像" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/host/profile/cover/route.ts
+++ b/app/api/host/profile/cover/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import axiosInstance from "@/api/axiosIntance";
+import type { ErrorResponse } from "@/types/api/response";
+import { formatAxiosError } from "@/utils/errors";
+import { UploadImageResponse } from "@/types/api/host";
+
+// 處理主辦單位封面照上傳請求
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<UploadImageResponse | ErrorResponse>> {
+  try {
+    // 檢查用戶是否已登入
+    const accessToken = request.headers.get('access_token');
+    if (!accessToken) {
+      return NextResponse.json(
+        { status: "failed", message: "請先登入會員" },
+        { status: 401 }
+      );
+    }
+
+    // 獲取上傳的檔案
+    const formData = await request.formData();
+    const avatar = formData.get('avatar'); // API 中使用 'avatar' 作為參數名稱
+    
+    // 驗證是否有檔案
+    if (!avatar || !(avatar instanceof File)) {
+      return NextResponse.json(
+        { status: "failed", message: "請選擇要上傳的圖片" },
+        { status: 400 }
+      );
+    }
+
+    // 檢查檔案大小
+    const sizeMB = avatar.size / (1024 * 1024);
+    if (sizeMB > 2) {
+      return NextResponse.json(
+        { status: "failed", message: "檔案太大，請選擇小於 2 MB 的圖片" },
+        { status: 400 }
+      );
+    }
+
+    // 檢查檔案類型
+    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+    if (!allowedTypes.includes(avatar.type)) {
+      return NextResponse.json(
+        { status: "failed", message: "只支援 JPEG、JPG、PNG 格式的圖片" },
+        { status: 400 }
+      );
+    }
+
+    try {
+      // 準備傳送到後端的 FormData
+      const apiFormData = new FormData();
+      apiFormData.append('avatar', avatar);
+
+      // 調用 API 上傳檔案
+      const response = await axiosInstance.post<UploadImageResponse>(
+        "/host/profile/cover", 
+        apiFormData, 
+        {
+          headers: {
+            Cookie: `access_token=${accessToken}`,
+            'Content-Type': 'multipart/form-data',
+          },
+          withCredentials: true,
+        }
+      );
+
+      // 返回成功回應
+      return NextResponse.json(response.data);
+    } catch (error: unknown) {
+      // 處理 Axios 錯誤
+      const apiErr = formatAxiosError(error);
+      
+      if (apiErr.httpCode === 404) {
+        return NextResponse.json(
+          { status: "failed", message: "尚未建立主辦方資料" },
+          { status: 404 }
+        );
+      } else {
+        return NextResponse.json(
+          { status: apiErr.status, message: apiErr.message },
+          { status: apiErr.httpCode }
+        );
+      }
+    }
+  } catch (error) {
+    console.error("處理主辦單位封面照上傳時發生錯誤:", error);
+    return NextResponse.json(
+      { status: "error", message: "伺服器錯誤，無法上傳主辦方封面照" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/host/profile/route.ts
+++ b/app/api/host/profile/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import axiosInstance from "@/api/axiosIntance";
+
+import type { ErrorResponse } from "@/types/api/response";
+import { formatAxiosError } from "@/utils/errors";
+import { CreateHostProfileRequest, HostProfileResponse } from "@/types/api/host";
+
+// 處理主辦單位註冊請求
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<HostProfileResponse | ErrorResponse>> {
+  try {
+    // 檢查用戶是否已登入
+    const accessToken = request.headers.get('access_token');
+    if (!accessToken) {
+      return NextResponse.json(
+        { status: "failed", message: "請先登入會員" },
+        { status: 401 }
+      );
+    }
+
+    // 解析 JSON 請求體
+    const profileData: CreateHostProfileRequest = await request.json();
+
+    try {
+      // 調用 API
+      const response = await axiosInstance.post<HostProfileResponse>("/host/profile", profileData, {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        withCredentials: true // 確保接收 cookie
+      });
+
+      // 從後端 response 獲取 cookie
+      const setCookies = response.headers["set-cookie"];
+      
+      // 創建回應
+      const res = NextResponse.json(response.data, { status: 201 });
+      
+      // 如果後端返回了 cookie（包含新的 access_token 和角色信息），將其傳遞給客戶端
+      if (setCookies) {
+        const cookieArray = Array.isArray(setCookies) ? setCookies : [setCookies];
+        for (const cookie of cookieArray) {
+          res.headers.append("Set-Cookie", cookie);
+        }
+      }
+      
+      return res;
+    } catch (error: unknown) {
+      // 處理 Axios 錯誤，使用格式化工具
+      const apiErr = formatAxiosError(error);
+      
+      // 保持與 API 文檔一致的錯誤回應格式
+      if (apiErr.httpCode === 409) {
+        return NextResponse.json(
+          { status: "failed", message: "您已經創建過主辦方資料" },
+          { status: 409 }
+        );
+      } else if (apiErr.httpCode === 400) {
+        return NextResponse.json(
+          { status: "failed", message: apiErr.message || "請填寫主辦方名稱、電話、Email、大頭貼等必填欄位" },
+          { status: 400 }
+        );
+      } else {
+        return NextResponse.json(
+          { status: apiErr.status, message: apiErr.message },
+          { status: apiErr.httpCode }
+        );
+      }
+    }
+  } catch (error) {
+    console.error("處理主辦單位註冊時發生錯誤:", error);
+    return NextResponse.json(
+      { status: "error", message: "伺服器錯誤" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,10 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col h-screen`}
       >
-        <HeaderNavBar username={user?.data?.member?.username??''}/>
+        <HeaderNavBar 
+          username={user?.data?.member?.username ?? ''} 
+          userRole={user?.data?.member?.role}
+        />
         <main className="flex-1 overflow-auto">
           {children}
         </main>

--- a/components/CreateHostModal/CreateHostForm/ImageUploadSection/index.tsx
+++ b/components/CreateHostModal/CreateHostForm/ImageUploadSection/index.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React, { useRef } from 'react';
+import Image from 'next/image';
+
+type ImageUploadSectionProps = {
+  /** 頭貼預覽圖片 */
+  photoPreview: string | null;
+  /** 背景圖預覽圖片 */
+  backgroundPreview: string | null;
+  /** 頭貼檔案變更事件 */
+  onPhotoChange: (file: File | null) => void;
+  /** 背景圖檔案變更事件 */
+  onBackgroundChange: (file: File | null) => void;
+  /** 頭貼錯誤訊息 */
+  photoError?: string;
+  /** 背景圖錯誤訊息 */
+  backgroundError?: string;
+};
+
+export function ImageUploadSection({
+  photoPreview,
+  backgroundPreview,
+  onPhotoChange,
+  onBackgroundChange,
+  photoError,
+  backgroundError
+}: ImageUploadSectionProps) {
+  const photoInputRef = useRef<HTMLInputElement>(null);
+  const backgroundInputRef = useRef<HTMLInputElement>(null);
+
+  // 處理點擊頭貼上傳區域
+  const handlePhotoAreaClick = () => {
+    photoInputRef.current?.click();
+  };
+
+  // 處理點擊背景圖上傳區域
+  const handleBackgroundAreaClick = () => {
+    backgroundInputRef.current?.click();
+  };
+
+  // 處理頭貼檔案選擇
+  const handlePhotoFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    
+    // 驗證檔案
+    if (file && file.size === 0) {
+      onPhotoChange(null);  // 將空檔案當作無檔案處理
+    } else if (file && !['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+      onPhotoChange(null);  // 將不支援的檔案類型當作無檔案處理
+    } else {
+      onPhotoChange(file);
+    }
+    
+    // 重置 input 值，確保同一檔案可以再次選擇
+    e.target.value = '';
+  };
+
+  // 處理背景圖檔案選擇
+  const handleBackgroundFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    
+    // 驗證檔案
+    if (file && file.size === 0) {
+      onBackgroundChange(null);  // 將空檔案當作無檔案處理
+    } else if (file && !['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+      onBackgroundChange(null);  // 將不支援的檔案類型當作無檔案處理
+    } else {
+      onBackgroundChange(file);
+    }
+    
+    // 重置 input 值，確保同一檔案可以再次選擇
+    e.target.value = '';
+  };
+
+  return (
+    <div className="form-control mt-6 w-full">
+      <label className="label">
+        <span className="label-text text-lg font-medium">主辦方圖片<span className="text-error">*</span></span>
+      </label>
+      <div className="max-w-4xl mx-auto relative">
+        {/* 背景圖上傳區塊 */}
+        <div 
+          className={`relative h-[300px] w-full border-2 border-dashed ${backgroundError ? 'border-error' : 'border-base-300'} rounded-lg flex flex-col items-center justify-center cursor-pointer overflow-hidden`}
+          onClick={handleBackgroundAreaClick}
+        >
+          {backgroundPreview ? (
+            <>
+              <Image 
+                src={backgroundPreview}
+                alt="主辦方背景圖片預覽" 
+                fill
+                sizes="100vw"
+                className="object-cover animate-fadeIn"
+                priority
+              />                
+              <div className="absolute inset-0 bg-black bg-opacity-30 opacity-0 hover:opacity-100 transition-opacity flex items-center justify-center">
+                <span className="text-white font-medium">點擊更換背景圖片</span>
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 text-base-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              <p className="mt-4 text-base font-medium text-center">主辦方背景圖片<span className="text-error ml-1">*</span></p>
+              <p className="text-sm text-center text-base-content/70 mt-1">點擊上傳（必填）</p>
+            </div>
+          )}
+        </div>
+        
+        {/* 頭貼上傳區塊 */}
+        <div 
+          className="absolute top-5 left-5 z-20"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div 
+            className={`relative w-[120px] h-[120px] rounded-full border-4 border-base-100 ${photoError ? 'ring-2 ring-error' : ''} overflow-hidden cursor-pointer shadow-md`}
+            onClick={handlePhotoAreaClick}
+          >
+            {photoPreview ? (
+              <>
+                <Image 
+                  src={photoPreview}
+                  alt="主辦方頭貼預覽" 
+                  fill
+                  sizes="150px"
+                  className="object-cover z-20"
+                  priority
+                />
+                <div className="absolute inset-0 bg-black bg-opacity-30 opacity-0 hover:opacity-100 transition-opacity flex items-center justify-center">
+                  <span className="text-white font-medium">點擊更換頭貼</span>
+                </div>
+              </>
+            ) : (
+              <div className="w-full h-full flex flex-col items-center justify-center bg-base-200">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-12 w-12 text-base-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                <p className="text-sm text-center mt-2">上傳頭貼<span className="text-error ml-1">*</span></p>
+              </div>
+            )}
+          </div>
+          
+          <div className={`text-error text-xs mt-2 absolute -bottom-6 left-0 right-0 text-center p-1 ${photoError ? 'opacity-100' : 'opacity-0'} transition-opacity duration-300`}>
+            {photoError || ' '}
+          </div>
+        </div>
+        
+        <div className={`text-error text-xs mt-1 p-1 ${backgroundError ? 'opacity-100' : 'opacity-0'} transition-opacity duration-300`}>
+          {backgroundError || ' '}
+        </div>
+      </div>
+      
+      {/* 隱藏的檔案輸入元素 */}
+      <input 
+        type="file"
+        ref={photoInputRef}
+        className="hidden" 
+        accept="image/jpeg,image/png,image/webp"
+        onChange={handlePhotoFileChange}
+      />
+      <input 
+        type="file"
+        ref={backgroundInputRef}
+        className="hidden" 
+        accept="image/jpeg,image/png,image/webp"
+        onChange={handleBackgroundFileChange}
+      />
+      
+      <div className="text-xs mt-2 max-w-4xl mx-auto text-center text-base-content/70">
+        支援格式: JPG, PNG, WebP (最大 2MB)
+      </div>
+    </div>
+  );
+}
+
+export default ImageUploadSection;

--- a/components/CreateHostModal/CreateHostForm/index.tsx
+++ b/components/CreateHostModal/CreateHostForm/index.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import React, { useImperativeHandle, useState } from "react";
+import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FormHandle } from "@/components/CreateHostModal";
+import { hostProfileSchema, HostProfileFormType } from "@/schema/HostProfileForm";
+import { useCreateHostProfile } from "@/swr/host/useHostProfile";
+import { useRouter } from "next/navigation";
+import { useHostAvatarUpload, useHostCoverUpload } from "@/swr/host/useHostProfileImage";
+import FormHookInput from "@/components/FormHookInput";
+import ImageUploadSection from "./ImageUploadSection";
+
+interface CreateHostFormProps {
+  ref: React.Ref<FormHandle>;
+  close: () => void;
+  onSuccess: () => void;
+}
+
+export default React.forwardRef<FormHandle, Omit<CreateHostFormProps, "ref">>(
+  function CreateHostForm({ close, onSuccess }, ref) {
+    const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+    const [backgroundPreview, setBackgroundPreview] = useState<string | null>(null);
+    const router = useRouter();
+
+    const {
+      register,
+      handleSubmit,
+      reset,
+      clearErrors,
+      setValue,
+      formState: { errors },
+    } = useForm<HostProfileFormType>({
+      resolver: zodResolver(hostProfileSchema),
+      shouldUnregister: true,
+    });
+
+    const { createHost, isLoading } = useCreateHostProfile();
+
+    // 暴露表單重設函式給父元件
+    useImperativeHandle(ref, () => ({
+      resetForm: () => {
+        reset();
+        clearErrors();
+        setPhotoPreview(null);
+        setBackgroundPreview(null);
+      },
+    }), [reset, clearErrors]);
+
+    // 處理照片選擇
+    const handlePhotoChange = (file: File | null) => {
+      setValue('photo', file);
+      
+      // 建立預覽
+      if (file) {
+        // 清除錯誤訊息
+        clearErrors('photo');
+        
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          setPhotoPreview(e.target?.result as string);
+        };
+        reader.readAsDataURL(file);
+      } else {
+        setPhotoPreview(null);
+      }
+    };
+
+    // 處理背景照片選擇
+    const handleBackgroundChange = (file: File | null) => {
+      setValue('photo_background', file);
+      
+      // 建立預覽
+      if (file) {
+        // 清除錯誤訊息
+        clearErrors('photo_background');
+        
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          setBackgroundPreview(e.target?.result as string);
+        };
+        reader.readAsDataURL(file);
+      } else {
+        setBackgroundPreview(null);
+      }
+    };
+
+    // 圖片上傳功能的 hook
+    const { uploadAvatar } = useHostAvatarUpload();
+    const { uploadCover } = useHostCoverUpload();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    
+    // 表單提交處理
+    const onSubmit = async (data: HostProfileFormType) => {
+      try {
+        setIsSubmitting(true);
+        
+        // 驗證是否有上傳圖片並確保檔案有效
+        let hasError = false;
+        
+        // 檢查主辦方頭像
+        if (!data.photo) {
+          setValue('photo', null, { shouldValidate: true });
+          hasError = true;
+        } else if (!(data.photo instanceof File) || data.photo.size === 0) {
+          toast.error('頭像檔案無效或為空');
+          setValue('photo', null, { shouldValidate: true });
+          hasError = true;
+        }
+        
+        // 檢查背景圖片
+        if (!data.photo_background) {
+          setValue('photo_background', null, { shouldValidate: true });
+          hasError = true;
+        } else if (!(data.photo_background instanceof File) || data.photo_background.size === 0) {
+          toast.error('背景圖片檔案無效或為空');
+          setValue('photo_background', null, { shouldValidate: true });
+          hasError = true;
+        }
+        
+        if (hasError) {
+          setIsSubmitting(false);
+          return;
+        }
+        
+        // 先提交主辦方基本資料 (使用預設圖片)
+        const defaultPhotoUrl = "https://storage.googleapis.com/your-bucket/default/host-avatar.png"; 
+        const defaultBackgroundUrl = "https://storage.googleapis.com/your-bucket/default/host-background.png";
+        
+        await createHost({
+          name: data.name,
+          description: data.description,
+          email: data.email,
+          phone: data.phone,
+          photo_url: defaultPhotoUrl,
+          photo_background_url: defaultBackgroundUrl
+        });
+        
+        toast.success('主辦方資料建立成功');
+        
+        // 成功建立主辦方後，再上傳圖片
+        try {
+          // 上傳主辦方頭像並取得 URL
+          if (data.photo instanceof File && data.photo.size > 0) {
+            
+            toast.loading('上傳主辦方頭像中...', { id: 'avatar-upload' });
+            await uploadAvatar(data.photo);
+            toast.success('主辦方頭像上傳成功', { id: 'avatar-upload' });
+          }
+          
+          // 上傳背景圖片並取得 URL
+          if (data.photo_background instanceof File && data.photo_background.size > 0) {
+            // 顯示檔案資訊以便偵錯
+            toast.loading('上傳背景圖片中...', { id: 'cover-upload' });
+            await uploadCover(data.photo_background);
+            toast.success('背景圖片上傳成功', { id: 'cover-upload' });
+          }
+          
+          // 圖片已上傳到主辦方帳戶，不需要額外更新主辦方資料
+          
+          // 完成後關閉表單並重新整理
+          router.refresh();
+          onSuccess();
+        } catch (error) {
+          console.error("圖片上傳失敗:", error);
+          
+          // 提供更具體的錯誤訊息
+          let errorMessage = '主辦方建立成功，但圖片上傳失敗';
+          if (error instanceof Error) {
+            errorMessage = `主辦方建立成功，但圖片上傳失敗: ${error.message}`;
+            
+            // 如果是 "請上傳圖片" 錯誤，提供更明確的指引
+            if (error.message.includes('請上傳圖片')) {
+              errorMessage += '。請確認圖片格式正確且未損壞。';
+            }
+          }
+          
+          toast.error(errorMessage);
+          
+          // 儘管圖片上傳失敗，仍然關閉表單並重新整理頁面
+          router.refresh();
+          onSuccess();
+        }
+      } catch (error) {
+        // 處理錯誤並顯示給用戶
+        console.error(error);
+        const errorMessage = error instanceof Error ? error.message : "建立主辦方資料失敗";
+        toast.error(`錯誤：${errorMessage}`);
+      } finally {
+        setIsSubmitting(false);
+      }
+    };
+
+    return (
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <ImageUploadSection
+          photoPreview={photoPreview}
+          backgroundPreview={backgroundPreview}
+          onPhotoChange={handlePhotoChange}
+          onBackgroundChange={handleBackgroundChange}
+          photoError={errors.photo?.message as string | undefined}
+          backgroundError={errors.photo_background?.message as string | undefined}
+        />
+        
+        <FormHookInput
+          label="主辦單位名稱"
+          type="text"
+          placeholder="請填入主辦單位名稱"
+          register={register("name")}
+          error={errors.name}
+        />
+
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">主辦單位描述<span className="text-error">*</span></span>
+          </label>
+          <textarea
+            {...register("description")}
+            placeholder="請描述主辦單位特色與活動方向"
+            className={`textarea textarea-bordered h-24 ${errors.description ? 'textarea-error' : ''}`}
+          />
+          {errors.description && (
+            <label className="label">
+              <span className="label-text-alt text-error">{errors.description.message}</span>
+            </label>
+          )}
+        </div>
+
+        <FormHookInput
+          label="聯絡信箱"
+          type="email"
+          placeholder="請填入聯絡信箱"
+          register={register("email")}
+          error={errors.email}
+        />
+
+        <FormHookInput
+          label="聯絡電話"
+          type="tel"
+          placeholder="請填入聯絡電話 (格式: 0912345678)"
+          register={register("phone")}
+          error={errors.phone}
+        />
+
+        <div className="mt-6 flex space-x-4">
+          <button 
+            type="button" 
+            className="btn btn-outline flex-1"
+            onClick={close}
+            disabled={isLoading || isSubmitting}
+          >
+            取消
+          </button>
+          <button 
+            type="submit" 
+            className="btn-primary flex-1"
+            disabled={isLoading || isSubmitting}
+          >
+            {isLoading || isSubmitting ? <span className="loading loading-spinner"></span> : '提交'}
+          </button>
+        </div>
+      </form>
+    );
+  }
+);

--- a/components/CreateHostModal/index.tsx
+++ b/components/CreateHostModal/index.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useRef } from "react";
+import DialogModal from "@/components/DialogModal";
+import CreateHostForm from "@/components/CreateHostModal/CreateHostForm";
+import { useRouter } from "next/navigation";
+
+// 表單操作的參考型別
+export type FormHandle = {
+  resetForm: () => void;
+};
+
+interface CreateHostModalProps {
+  onSuccess?: () => void;
+}
+
+export default function CreateHostModal({ onSuccess }: CreateHostModalProps) {
+  const modalRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<FormHandle>(null);
+  const router = useRouter();
+
+  // 關閉彈窗
+  function closeModal(): void {
+    if (modalRef.current) {
+      modalRef.current.checked = false; // 關閉 modal
+    }
+  }
+
+  // 處理註冊成功
+  function handleSuccess() {
+    // 先關閉彈窗
+    closeModal();
+    
+    // 呼叫外部成功回調
+    if (onSuccess) {
+      onSuccess();
+    } else {
+      // 默認行為：導向建立活動頁面
+      // 刷新數據並導航到創建活動頁面
+      router.refresh();
+      router.push('/create-activity');
+    }
+  }
+
+  return (
+    <>
+      <label htmlFor="create-host" className="flex items-center">
+        辦活動
+      </label>
+      <DialogModal modalWidth="max-w-5xl" id="create-host" modalRef={modalRef}>
+        <p className="text-3xl text-base-200 text-center">
+          成為主辦方
+        </p>
+        <p className="text-center text-gray-600 mt-1 mb-4">
+          請填寫以下資訊，完成後即可開始建立活動
+        </p>
+        <CreateHostForm ref={formRef} close={closeModal} onSuccess={handleSuccess} />
+      </DialogModal>
+    </>
+  );
+}

--- a/components/DialogModal/index.tsx
+++ b/components/DialogModal/index.tsx
@@ -1,20 +1,24 @@
 "use client";
 import React from "react";
 
-export default function DialogModal({
-  id,
-  children,
-  modalRef
-}: {
+type DialogModalProps = {
   id: string;
   children: React.ReactNode;
   modalRef?: React.RefObject<HTMLInputElement | null>;
-}) {
+  modalWidth?: `max-w-${string}`;
+};
+
+export default function DialogModal({
+  id,
+  children,
+  modalRef,
+  modalWidth
+}: DialogModalProps) {
   return (
     <>
       <input type="checkbox" ref={modalRef} id={id} className="modal-toggle" />
       <div className="modal" role="dialog">
-        <div className="modal-box  bg-gray-50">{children}</div>
+        <div className={`modal-box bg-gray-50 ${modalWidth}`}>{children}</div>
         <label className="modal-backdrop" htmlFor={id}>
           Close
         </label>

--- a/components/HeaderNavBar/index.tsx
+++ b/components/HeaderNavBar/index.tsx
@@ -4,14 +4,23 @@ import Image from "next/image";
 import LoginLabelModal from "@/components/LoginLabelModal"
 import RegisterModal from "@/components/RegisterModal";
 import MemberMenu from "@/components/HeaderNavBar/MemberMenu"
-import { usePathname } from 'next/navigation'
+
+import { usePathname, useRouter } from 'next/navigation'
+import CreateHostModal from "../CreateHostModal";
 
 interface PropsType {
-  username: string
+  username: string;
+  userRole?: string;
 }
-export default function HeaderNavBar({username}:PropsType) {
-  const pathname = usePathname()
-  const isHome = pathname === '/'
+
+export default function HeaderNavBar({username, userRole}:PropsType) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const isHome = pathname === '/';
+  
+  // 檢查使用者是否為主辦方
+  const isHost = userRole === 'host';
+  
   return (
     < div className={[
       'navbar fixed inset-x-0  w-full px-[16%] z-10',
@@ -30,11 +39,21 @@ export default function HeaderNavBar({username}:PropsType) {
         <Link href="/" className="flex items-center">
           <p className="text-neutral-950 text-base">活動列表</p>
         </Link>
-        <Link href="/event" className="flex items-center">
-          <p className="text-neutral-950 text-base">辦活動</p>
-        </Link>
+        
+        {username ? (
+          isHost ? (
+            <Link href="/create-activity" className="flex items-center">
+              <p className="text-neutral-950 text-base">辦活動</p>
+            </Link>
+          ) : (
+            <CreateHostModal onSuccess={() => {
+              router.refresh();
+              router.push('/create-activity')
+            }} />
+          )
+        ) : null }
       
-        { username? <MemberMenu user={username}/> : 
+        { username ? <MemberMenu user={username}/> : 
         <div className="flex space-x-3">
            <LoginLabelModal />
            <RegisterModal />

--- a/schema/HostProfileForm/index.ts
+++ b/schema/HostProfileForm/index.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+// 主辦單位資料表單驗證結構
+export const hostProfileSchema = z.object({
+  name: z.string()
+    .min(2, { message: "主辦單位名稱至少需要 2 個字元" })
+    .max(50, { message: "主辦單位名稱不得超過 50 個字元" }),
+  
+  description: z.string()
+    .min(10, { message: "描述至少需要 10 個字元" })
+    .max(500, { message: "描述不得超過 500 個字元" }),
+  
+  email: z.string()
+    .email({ message: "請輸入有效的電子郵件地址" }),
+  
+  phone: z.string()
+    .regex(/^09\d{8}$/, { message: "請輸入有效的台灣手機號碼，格式為09XXXXXXXX" }),
+  
+  photo: z.instanceof(File, { message: "請上傳主辦方頭像" })
+    .refine(
+      (file) => file.size <= 2 * 1024 * 1024,
+      { message: "照片大小不得超過 2MB" }
+    )
+    .optional()
+    .or(z.literal(null))
+    .superRefine((val, ctx) => {
+      if (!val) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "請上傳主辦方頭像",
+        });
+      }
+    }),
+  
+  photo_background: z.instanceof(File, { message: "請上傳主辦方背景圖片" })
+    .refine(
+      (file) => file.size <= 2 * 1024 * 1024,
+      { message: "背景照片大小不得超過 2MB" }
+    )
+    .optional()
+    .or(z.literal(null))
+    .superRefine((val, ctx) => {
+      if (!val) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "請上傳主辦方背景圖片",
+        });
+      }
+    }),
+  
+  photo_url: z.string().optional(),
+  photo_background_url: z.string().optional()
+});
+
+// 轉換成 TypeScript 型別使用
+export type HostProfileFormType = z.infer<typeof hostProfileSchema>;

--- a/swr/host/useHostProfile.ts
+++ b/swr/host/useHostProfile.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback } from "react";
+import useSWRMutation from 'swr/mutation';
+import toast from 'react-hot-toast';
+import axios from 'axios';
+
+import axiosInstance from "@/api/axiosIntance";
+import { CreateHostProfileRequest, HostProfileResponse } from "@/types/api/host";
+
+// 建立主辦單位資料 API
+async function createHostProfile(url: string, { arg }: { arg: CreateHostProfileRequest }) {
+  try {
+    const response = await axiosInstance.post<HostProfileResponse>("/host/profile", arg, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    
+    return response.data;
+  } catch (error: unknown) {
+    // 處理錯誤
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.message || "註冊主辦單位失敗");
+    }
+    throw new Error("註冊主辦單位時發生錯誤");
+  }
+}
+
+// 主辦單位註冊 Hook
+export function useCreateHostProfile() {
+  const { trigger, isMutating, error, data } = useSWRMutation('/host/profile', createHostProfile);
+  
+  // 包裝 trigger 函式處理更佳的錯誤處理
+  const createHost = useCallback(async (profileData: CreateHostProfileRequest) => {
+    try {
+      const result = await trigger(profileData);
+      
+      // 成功提示
+      toast.success(result.message || "主辦單位註冊成功！");
+      return result;
+    } catch (err) {
+      // 錯誤提示
+      const errorMessage = err instanceof Error ? err.message : "註冊主辦單位時發生錯誤";
+      toast.error(errorMessage);
+      throw err;
+    }
+  }, [trigger]);
+  
+  return {
+    createHost,
+    isLoading: isMutating,
+    error,
+    data
+  };
+}

--- a/swr/host/useHostProfileImage.ts
+++ b/swr/host/useHostProfileImage.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback } from "react";
+import useSWRMutation from 'swr/mutation';
+import toast from 'react-hot-toast';
+import axios from 'axios';
+import axiosInstance from "@/api/axiosIntance";
+import { UploadImageResponse } from "@/types/api/host";
+
+// 上傳主辦方頭像
+async function uploadHostAvatar(_key: string, { arg }: { arg: File }) {
+  const formData = new FormData();
+  formData.append("file", arg);
+  
+  try {
+    const response = await axiosInstance.post<UploadImageResponse>("/host/profile/avatar", formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    
+    return response.data;
+  } catch (error: unknown) {
+    // 處理錯誤
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.message || "上傳頭像失敗");
+    }
+    throw new Error("上傳頭像時發生錯誤");
+  }
+}
+
+// 上傳主辦方封面照
+async function uploadHostCover(_key: string, { arg }: { arg: File }) {
+  const formData = new FormData();
+  formData.append("file", arg);
+  
+  try {
+    const response = await axiosInstance.post<UploadImageResponse>("/host/profile/cover", formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    
+    return response.data;
+  } catch (error: unknown) {
+    // 處理錯誤
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.message || "上傳封面照失敗");
+    }
+    throw new Error("上傳封面照時發生錯誤");
+  }
+}
+
+// 主辦方頭像上傳 Hook
+export function useHostAvatarUpload() {
+  const { trigger, isMutating, error, data } = useSWRMutation('/host/profile/avatar', uploadHostAvatar);
+  
+  const uploadAvatar = useCallback(async (file: File) => {
+    // 確保檔案不是空的且確實是檔案
+    if (!file || !(file instanceof File) || file.size === 0) {
+      const errorMessage = "請選擇有效的頭像圖片檔案";
+      toast.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    
+    // 檢查檔案類型是否為圖片
+    const validImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!validImageTypes.includes(file.type)) {
+      const errorMessage = `不支援的檔案類型: ${file.type}，請選擇 JPG, PNG, WebP 或 GIF 格式的圖片`;
+      toast.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    
+    try {
+      const result = await trigger(file);
+      toast.success(result.message || "頭像上傳成功！");
+      return result.data.photo_url;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "上傳頭像時發生錯誤";
+      toast.error(errorMessage);
+      throw err;
+    }
+  }, [trigger]);
+  
+  return {
+    uploadAvatar,
+    isLoading: isMutating,
+    error,
+    data
+  };
+}
+
+// 主辦方封面照上傳 Hook
+export function useHostCoverUpload() {
+  const { trigger, isMutating, error, data } = useSWRMutation('/host/profile/cover', uploadHostCover);
+  
+  const uploadCover = useCallback(async (file: File) => {
+    // 確保檔案不是空的且確實是檔案
+    if (!file || !(file instanceof File) || file.size === 0) {
+      const errorMessage = "請選擇有效的背景圖片檔案";
+      toast.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    
+    // 檢查檔案類型是否為圖片
+    const validImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!validImageTypes.includes(file.type)) {
+      const errorMessage = `不支援的檔案類型: ${file.type}，請選擇 JPG, PNG, WebP 或 GIF 格式的圖片`;
+      toast.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    
+    try {
+      const result = await trigger(file);
+      toast.success(result.message || "封面照上傳成功！");
+      return result.data.photo_url;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "上傳封面照時發生錯誤";
+      toast.error(errorMessage);
+      throw err;
+    }
+  }, [trigger]);
+  
+  return {
+    uploadCover,
+    isLoading: isMutating,
+    error,
+    data
+  };
+}

--- a/types/api/host/index.ts
+++ b/types/api/host/index.ts
@@ -1,0 +1,55 @@
+// 主辦單位 API 相關型別定義
+
+import { SuccessResponse } from '../response';
+
+// 主辦單位資料模型
+export interface HostProfile {
+  /** 主辦方 id */
+  id: string;
+  /** 會員 id */
+  member_id: string;
+  /** 主辦方名稱 */
+  name: string;
+  /** 主辦方描述 */
+  description: string;
+  /** 主辦方電子郵件 */
+  email: string;
+  /** 主辦方電話 */
+  phone: string;
+  /** 主辦方頭像 */
+  photo_url?: string;
+  /** 主辦方背景圖片 */
+  photo_background_url?: string;
+  /** 主辦方狀態 */
+  verification_status?: 'pending' | 'verified' | 'rejected';
+  updated_at?: string;
+}
+
+// 主辦單位創建請求體 (For API call)
+export interface CreateHostProfileRequest {
+  /** 主辦方名稱 */
+  name: string;
+  /** 主辦方描述 */
+  description: string;
+  /** 主辦方電子郵件 */
+  email: string;
+  /** 主辦方電話 */
+  phone: string;
+  /** 主辦方頭像 */
+  photo_url: string;
+  /** 主辦方背景圖片 */
+  photo_background_url: string;
+}
+
+// 更新主辦方資料請求體
+export type UpdateHostProfileRequest = Partial<CreateHostProfileRequest>;
+
+// 上傳圖片回應
+export type UploadImageResponse = SuccessResponse<{
+  photo_url: string;
+}>;
+
+// 主辦單位 API 回應
+export type HostProfileResponse = SuccessResponse<{
+  host_info: HostProfile;
+}>;


### PR DESCRIPTION
更新 RootLayout，將用戶角色傳遞給 HeaderNavBar。
修改 DialogModal，加入 modalWidth 屬性以實現可自定義寬度。
實現用於上傳主辦方頭像和封面圖片的 API 路由。
創建包含圖片上傳區塊的完整主辦方資料創建表單。
整合圖片上傳驗證機制，並提供適當的錯誤處理。
使用 SWR 新增管理主辦方資料創建和圖片上傳的 hooks。
定義主辦方表單驗證用的 Zod schema。
更新主辦方 API 響應和請求的類型定義。