### PR TITLE
fix: 修正創建主辦方表單及頭像與封面照上傳等 API 的問題

### DIFF
--- a/app/api/host/profile/avatar/route.ts
+++ b/app/api/host/profile/avatar/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import axiosInstance from "@/api/axiosIntance";
-import type { ErrorResponse } from "@/types/api/response";
-import { formatAxiosError } from "@/utils/errors";
-import { UploadImageResponse } from "@/types/api/host";
+import { NextRequest, NextResponse } from 'next/server';
+import axiosInstance from '@/api/axiosIntance';
+import type { ErrorResponse } from '@/types/api/response';
+import { formatAxiosError } from '@/utils/errors';
+import { UploadImageResponse } from '@/types/api/host';
 
 // 處理主辦單位頭像上傳請求
 export async function POST(
@@ -13,54 +13,22 @@ export async function POST(
     const accessToken = request.headers.get('access_token');
     if (!accessToken) {
       return NextResponse.json(
-        { status: "failed", message: "請先登入會員" },
+        { status: 'failed', message: '請先登入會員' },
         { status: 401 }
-      );
-    }
-
-    // 獲取上傳的檔案
-    const formData = await request.formData();
-    const avatar = formData.get('avatar');
-    
-    // 驗證是否有檔案
-    if (!avatar || !(avatar instanceof File)) {
-      return NextResponse.json(
-        { status: "failed", message: "請選擇要上傳的圖片" },
-        { status: 400 }
-      );
-    }
-
-    // 檢查檔案大小
-    const sizeMB = avatar.size / (1024 * 1024);
-    if (sizeMB > 2) {
-      return NextResponse.json(
-        { status: "failed", message: "檔案太大，請選擇小於 2 MB 的圖片" },
-        { status: 400 }
-      );
-    }
-
-    // 檢查檔案類型
-    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
-    if (!allowedTypes.includes(avatar.type)) {
-      return NextResponse.json(
-        { status: "failed", message: "只支援 JPEG、JPG、PNG 格式的圖片" },
-        { status: 400 }
       );
     }
 
     try {
       // 準備傳送到後端的 FormData
-      const apiFormData = new FormData();
-      apiFormData.append('avatar', avatar);
+      const formData = await request.formData();
 
       // 調用 API 上傳檔案
       const response = await axiosInstance.post<UploadImageResponse>(
-        "/host/profile/avatar", 
-        apiFormData, 
+        '/host/profile/avatar',
+        formData,
         {
           headers: {
             Cookie: `access_token=${accessToken}`,
-            'Content-Type': 'multipart/form-data',
           },
           withCredentials: true,
         }
@@ -71,10 +39,10 @@ export async function POST(
     } catch (error: unknown) {
       // 處理 Axios 錯誤
       const apiErr = formatAxiosError(error);
-      
+
       if (apiErr.httpCode === 404) {
         return NextResponse.json(
-          { status: "failed", message: "尚未建立主辦方資料" },
+          { status: 'failed', message: '尚未建立主辦方資料' },
           { status: 404 }
         );
       } else {
@@ -85,9 +53,9 @@ export async function POST(
       }
     }
   } catch (error) {
-    console.error("處理主辦單位頭像上傳時發生錯誤:", error);
+    console.error('處理主辦單位頭像上傳時發生錯誤:', error);
     return NextResponse.json(
-      { status: "error", message: "伺服器錯誤，無法上傳主辦方頭像" },
+      { status: 'error', message: '伺服器錯誤，無法上傳主辦方頭像' },
       { status: 500 }
     );
   }

--- a/app/api/host/profile/cover/route.ts
+++ b/app/api/host/profile/cover/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import axiosInstance from "@/api/axiosIntance";
-import type { ErrorResponse } from "@/types/api/response";
-import { formatAxiosError } from "@/utils/errors";
-import { UploadImageResponse } from "@/types/api/host";
+import { NextRequest, NextResponse } from 'next/server';
+import axiosInstance from '@/api/axiosIntance';
+import type { ErrorResponse } from '@/types/api/response';
+import { formatAxiosError } from '@/utils/errors';
+import { UploadImageResponse } from '@/types/api/host';
 
 // 處理主辦單位封面照上傳請求
 export async function POST(
@@ -13,54 +13,23 @@ export async function POST(
     const accessToken = request.headers.get('access_token');
     if (!accessToken) {
       return NextResponse.json(
-        { status: "failed", message: "請先登入會員" },
+        { status: 'failed', message: '請先登入會員' },
         { status: 401 }
       );
     }
 
-    // 獲取上傳的檔案
-    const formData = await request.formData();
-    const avatar = formData.get('avatar'); // API 中使用 'avatar' 作為參數名稱
     
-    // 驗證是否有檔案
-    if (!avatar || !(avatar instanceof File)) {
-      return NextResponse.json(
-        { status: "failed", message: "請選擇要上傳的圖片" },
-        { status: 400 }
-      );
-    }
-
-    // 檢查檔案大小
-    const sizeMB = avatar.size / (1024 * 1024);
-    if (sizeMB > 2) {
-      return NextResponse.json(
-        { status: "failed", message: "檔案太大，請選擇小於 2 MB 的圖片" },
-        { status: 400 }
-      );
-    }
-
-    // 檢查檔案類型
-    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png'];
-    if (!allowedTypes.includes(avatar.type)) {
-      return NextResponse.json(
-        { status: "failed", message: "只支援 JPEG、JPG、PNG 格式的圖片" },
-        { status: 400 }
-      );
-    }
 
     try {
-      // 準備傳送到後端的 FormData
-      const apiFormData = new FormData();
-      apiFormData.append('avatar', avatar);
-
+      // 獲取上傳的檔案
+      const formData = await request.formData();
       // 調用 API 上傳檔案
       const response = await axiosInstance.post<UploadImageResponse>(
-        "/host/profile/cover", 
-        apiFormData, 
+        '/host/profile/cover',
+        formData,
         {
           headers: {
             Cookie: `access_token=${accessToken}`,
-            'Content-Type': 'multipart/form-data',
           },
           withCredentials: true,
         }
@@ -71,10 +40,10 @@ export async function POST(
     } catch (error: unknown) {
       // 處理 Axios 錯誤
       const apiErr = formatAxiosError(error);
-      
+
       if (apiErr.httpCode === 404) {
         return NextResponse.json(
-          { status: "failed", message: "尚未建立主辦方資料" },
+          { status: 'failed', message: '尚未建立主辦方資料' },
           { status: 404 }
         );
       } else {
@@ -85,9 +54,9 @@ export async function POST(
       }
     }
   } catch (error) {
-    console.error("處理主辦單位封面照上傳時發生錯誤:", error);
+    console.error('處理主辦單位封面照上傳時發生錯誤:', error);
     return NextResponse.json(
-      { status: "error", message: "伺服器錯誤，無法上傳主辦方封面照" },
+      { status: 'error', message: '伺服器錯誤，無法上傳主辦方封面照' },
       { status: 500 }
     );
   }

--- a/app/api/host/profile/route.ts
+++ b/app/api/host/profile/route.ts
@@ -26,10 +26,9 @@ export async function POST(
       // 調用 API
       const response = await axiosInstance.post<HostProfileResponse>("/host/profile", profileData, {
         headers: {
-          authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
+          Cookie: `access_token=${accessToken}`,
         },
-        withCredentials: true // 確保接收 cookie
+        withCredentials: true,
       });
 
       // 從後端 response 獲取 cookie

--- a/schema/HostProfileForm/index.ts
+++ b/schema/HostProfileForm/index.ts
@@ -16,11 +16,17 @@ export const hostProfileSchema = z.object({
   phone: z.string()
     .regex(/^09\d{8}$/, { message: "請輸入有效的台灣手機號碼，格式為09XXXXXXXX" }),
   
-  photo: z.instanceof(File, { message: "請上傳主辦方頭像" })
-    .refine(
-      (file) => file.size <= 2 * 1024 * 1024,
-      { message: "照片大小不得超過 2MB" }
-    )
+  photo: z.any()
+    .refine((file) => {
+      // 伺服器端渲染時跳過檢查
+      if (typeof window === 'undefined') return true;
+      return file instanceof File;
+    }, { message: "請上傳主辦方頭像" })
+    .refine((file) => {
+      // 伺服器端渲染或無檔案時跳過檢查
+      if (typeof window === 'undefined' || !(file instanceof File)) return true;
+      return file.size <= 2 * 1024 * 1024;
+    }, { message: "照片大小不得超過 2MB" })
     .optional()
     .or(z.literal(null))
     .superRefine((val, ctx) => {
@@ -32,11 +38,17 @@ export const hostProfileSchema = z.object({
       }
     }),
   
-  photo_background: z.instanceof(File, { message: "請上傳主辦方背景圖片" })
-    .refine(
-      (file) => file.size <= 2 * 1024 * 1024,
-      { message: "背景照片大小不得超過 2MB" }
-    )
+  photo_background: z.any()
+    .refine((file) => {
+      // 伺服器端渲染時跳過檢查
+      if (typeof window === 'undefined') return true;
+      return file instanceof File;
+    }, { message: "請上傳主辦方背景圖片" })
+    .refine((file) => {
+      // 伺服器端渲染或無檔案時跳過檢查
+      if (typeof window === 'undefined' || !(file instanceof File)) return true;
+      return file.size <= 2 * 1024 * 1024;
+    }, { message: "背景照片大小不得超過 2MB" })
     .optional()
     .or(z.literal(null))
     .superRefine((val, ctx) => {

--- a/swr/host/useHostProfile.ts
+++ b/swr/host/useHostProfile.ts
@@ -1,56 +1,37 @@
-"use client";
-
-import { useCallback } from "react";
 import useSWRMutation from 'swr/mutation';
-import toast from 'react-hot-toast';
 import axios from 'axios';
-
-import axiosInstance from "@/api/axiosIntance";
 import { CreateHostProfileRequest, HostProfileResponse } from "@/types/api/host";
+import toast from 'react-hot-toast';
 
 // 建立主辦單位資料 API
-async function createHostProfile(url: string, { arg }: { arg: CreateHostProfileRequest }) {
-  try {
-    const response = await axiosInstance.post<HostProfileResponse>("/host/profile", arg, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-    
-    return response.data;
-  } catch (error: unknown) {
-    // 處理錯誤
-    if (axios.isAxiosError(error) && error.response) {
-      throw new Error(error.response.data.message || "註冊主辦單位失敗");
-    }
-    throw new Error("註冊主辦單位時發生錯誤");
-  }
-}
-
-// 主辦單位註冊 Hook
 export function useCreateHostProfile() {
-  const { trigger, isMutating, error, data } = useSWRMutation('/host/profile', createHostProfile);
-  
-  // 包裝 trigger 函式處理更佳的錯誤處理
-  const createHost = useCallback(async (profileData: CreateHostProfileRequest) => {
-    try {
-      const result = await trigger(profileData);
-      
-      // 成功提示
-      toast.success(result.message || "主辦單位註冊成功！");
-      return result;
-    } catch (err) {
-      // 錯誤提示
-      const errorMessage = err instanceof Error ? err.message : "註冊主辦單位時發生錯誤";
-      toast.error(errorMessage);
-      throw err;
+  const { isMutating, trigger, error, data } = useSWRMutation(
+    "/api/host/profile/create",
+    async (_key: string, { arg: payload }: { arg: CreateHostProfileRequest }) => {
+      try {
+        const response = await axios.post<HostProfileResponse>("/api/host/profile", payload, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        toast.success("主辦方資料建立成功");
+        return response.data;
+      } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+          const errorMessage = error.response.data.message || "主辦方資料建立失敗";
+          toast.error(errorMessage);
+          throw new Error(errorMessage);
+        }
+        throw new Error("主辦方資料建立發生錯誤");
+      }
     }
-  }, [trigger]);
-  
+  );
+
   return {
-    createHost,
-    isLoading: isMutating,
+    isMutating,
+    trigger,
+    data,
     error,
-    data
   };
 }

--- a/swr/host/useHostProfileImage.ts
+++ b/swr/host/useHostProfileImage.ts
@@ -1,130 +1,81 @@
-"use client";
-
-import { useCallback } from "react";
 import useSWRMutation from 'swr/mutation';
-import toast from 'react-hot-toast';
 import axios from 'axios';
-import axiosInstance from "@/api/axiosIntance";
-import { UploadImageResponse } from "@/types/api/host";
+import { UploadImageResponse } from '@/types/api/host';
+import toast from 'react-hot-toast';
 
-// 上傳主辦方頭像
-async function uploadHostAvatar(_key: string, { arg }: { arg: File }) {
-  const formData = new FormData();
-  formData.append("file", arg);
-  
-  try {
-    const response = await axiosInstance.post<UploadImageResponse>("/host/profile/avatar", formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    
-    return response.data;
-  } catch (error: unknown) {
-    // 處理錯誤
-    if (axios.isAxiosError(error) && error.response) {
-      throw new Error(error.response.data.message || "上傳頭像失敗");
-    }
-    throw new Error("上傳頭像時發生錯誤");
-  }
-}
-
-// 上傳主辦方封面照
-async function uploadHostCover(_key: string, { arg }: { arg: File }) {
-  const formData = new FormData();
-  formData.append("file", arg);
-  
-  try {
-    const response = await axiosInstance.post<UploadImageResponse>("/host/profile/cover", formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    
-    return response.data;
-  } catch (error: unknown) {
-    // 處理錯誤
-    if (axios.isAxiosError(error) && error.response) {
-      throw new Error(error.response.data.message || "上傳封面照失敗");
-    }
-    throw new Error("上傳封面照時發生錯誤");
-  }
-}
-
-// 主辦方頭像上傳 Hook
+// 上傳主辦方頭像的 Hook
 export function useHostAvatarUpload() {
-  const { trigger, isMutating, error, data } = useSWRMutation('/host/profile/avatar', uploadHostAvatar);
-  
-  const uploadAvatar = useCallback(async (file: File) => {
-    // 確保檔案不是空的且確實是檔案
-    if (!file || !(file instanceof File) || file.size === 0) {
-      const errorMessage = "請選擇有效的頭像圖片檔案";
-      toast.error(errorMessage);
-      throw new Error(errorMessage);
-    }
-    
-    // 檢查檔案類型是否為圖片
-    const validImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-    if (!validImageTypes.includes(file.type)) {
-      const errorMessage = `不支援的檔案類型: ${file.type}，請選擇 JPG, PNG, WebP 或 GIF 格式的圖片`;
-      toast.error(errorMessage);
-      throw new Error(errorMessage);
-    }
-    
-    try {
-      const result = await trigger(file);
-      toast.success(result.message || "頭像上傳成功！");
-      return result.data.photo_url;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "上傳頭像時發生錯誤";
-      toast.error(errorMessage);
-      throw err;
-    }
-  }, [trigger]);
-  
+  const { isMutating, trigger, error, data } = useSWRMutation(
+    '/api/host/profile/avatar',
+    async (_key: string, { arg }: { arg: File }) => {
+      const formData = new FormData();
+      formData.append('file', arg); // 修改欄位名稱為 'file'，與後端 controller 一致
+
+      try {
+        toast.loading('上傳主辦方頭像中...', { id: 'avatar-upload' });
+        const response = await axios.post<UploadImageResponse>(
+          '/api/host/profile/avatar',
+          formData,
+          {
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            },
+          }
+        );
+        toast.success('主辦方頭像上傳成功', { id: 'avatar-upload' });
+        return response.data;
+      } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+          throw new Error(error.response.data.message || '上傳頭像失敗');
+        }
+        throw new Error('上傳頭像時發生錯誤');
+      }
+    },
+    { throwOnError: true }
+  );
+
   return {
-    uploadAvatar,
-    isLoading: isMutating,
+    isMutating,
+    trigger,
+    data,
     error,
-    data
   };
 }
 
 // 主辦方封面照上傳 Hook
 export function useHostCoverUpload() {
-  const { trigger, isMutating, error, data } = useSWRMutation('/host/profile/cover', uploadHostCover);
-  
-  const uploadCover = useCallback(async (file: File) => {
-    // 確保檔案不是空的且確實是檔案
-    if (!file || !(file instanceof File) || file.size === 0) {
-      const errorMessage = "請選擇有效的背景圖片檔案";
-      toast.error(errorMessage);
-      throw new Error(errorMessage);
+  const { isMutating, trigger, error, data } = useSWRMutation(
+    '/api/host/profile/cover',
+    async (_key: string, { arg }: { arg: File }) => {
+      const formData = new FormData();
+      formData.append('file', arg); // 修改欄位名稱為 'file'，與後端 controller 一致
+
+      try {
+        toast.loading('上傳背景圖片中...', { id: 'cover-upload' });
+        const response = await axios.post<UploadImageResponse>(
+          '/api/host/profile/cover',
+          formData,
+          {
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            },
+          }
+        );
+        toast.success('背景圖片上傳成功', { id: 'cover-upload' });
+        return response.data;
+      } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+          throw new Error(error.response.data.message || '上傳封面照失敗');
+        }
+        throw new Error('上傳封面照時發生錯誤');
+      }
     }
-    
-    // 檢查檔案類型是否為圖片
-    const validImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-    if (!validImageTypes.includes(file.type)) {
-      const errorMessage = `不支援的檔案類型: ${file.type}，請選擇 JPG, PNG, WebP 或 GIF 格式的圖片`;
-      toast.error(errorMessage);
-      throw new Error(errorMessage);
-    }
-    
-    try {
-      const result = await trigger(file);
-      toast.success(result.message || "封面照上傳成功！");
-      return result.data.photo_url;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "上傳封面照時發生錯誤";
-      toast.error(errorMessage);
-      throw err;
-    }
-  }, [trigger]);
-  
+  );
+
   return {
-    uploadCover,
-    isLoading: isMutating,
+    isMutating,
+    trigger,
+    data,
     error,
-    data
   };
 }


### PR DESCRIPTION
- 更新頭像與封面照的上傳 API，統一使用 FormData 並修正檔案欄位名稱為 'file'。

- 移除不必要的檔案大小與類型驗證，改為在 schema 中進行伺服器端渲染時的檢查。

- 更新使用者介面，移除不必要的 toast 提示，簡化使用者體驗。