### PR TITLE
feat: 新增 metadata 設定於多個頁面以改善 SEO

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,6 +1,10 @@
-
 import CartItemCombineWrapper from '@/components/Cart/CartItemCombineWrapper';
 import { memberGetOrders } from '@/api/server-components/member/orders'
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: "購物車 | 森森不息"
+}
 
 export default async function CartPage() {
   const orderData = await memberGetOrders('Unpaid');

--- a/app/create-activity/page.tsx
+++ b/app/create-activity/page.tsx
@@ -1,7 +1,10 @@
-'use client';
-
 import React from 'react';
 import CreateActivityForm from './components/CreateActivityForm';
+
+export const metadata = {
+  title: '新增活動 | 森森不息',
+  description: '在這裡新增您的露營活動，吸引更多人參與',
+};
 
 function CreateActivityPage() {
   return (

--- a/app/event/[id]/page.tsx
+++ b/app/event/[id]/page.tsx
@@ -15,9 +15,9 @@ import type { Metadata } from 'next';
 
 // 動態產生 metadata，根據活動名稱顯示標題
 export async function generateMetadata(
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ): Promise<Metadata> {
-  const id = params.id;
+  const { id } = await params;
   const eventIdData = await getEventById(id);
   if (!eventIdData) {
     return {

--- a/app/event/[id]/page.tsx
+++ b/app/event/[id]/page.tsx
@@ -11,7 +11,40 @@ import EventNotice from "@/components/EventById/EventNotice";
 
 import { getEventById } from "@/api/server-components/event/eventId";
 import { redirect } from "next/navigation";
+import type { Metadata } from 'next';
 
+// 動態產生 metadata，根據活動名稱顯示標題
+export async function generateMetadata(
+  { params }: { params: { id: string } },
+): Promise<Metadata> {
+  const id = params.id;
+  const eventIdData = await getEventById(id);
+  if (!eventIdData) {
+    return {
+      title: '活動不存在 | 森森不息',
+      description: '找不到該活動資訊',
+      icons: { icon: '/header/logo_icon.svg' },
+    };
+  }
+  const coverImage = eventIdData.photos?.find((photo: { type: string }) => photo.type === 'cover')?.photo_url || '/main/main_bg_top_1.jpg';
+  return {
+    title: `${eventIdData.title} | 森森不息`,
+    description: eventIdData.description?.slice(0, 160) || '露營活動詳情',
+    openGraph: {
+      title: eventIdData.title,
+      description: eventIdData.description?.slice(0, 160) || '露營活動詳情',
+      images: [
+        {
+          url: coverImage,
+          width: 1200,
+          height: 630,
+          alt: eventIdData.title,
+        },
+      ],
+    },
+    icons: { icon: '/header/logo_icon.svg' },
+  };
+}
 // 假資料
 
 const sampleComment = [

--- a/app/event/page.tsx
+++ b/app/event/page.tsx
@@ -2,8 +2,14 @@ import type { GetEventsParams } from "@/types/api/event/allEvents";
 import EventFilterShell from "@/components/EventFilterShell";
 import RestButton from "@/components/EventFilterShell/ResetButton";
 import { getEventTags } from "@/api/server-components/event/tags";
+import { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "活動列表 | 森森不息",
+  description: "探索各種露營活動，篩選符合您需求的活動",
+}
 
 export default async function EventPage({
   searchParams,

--- a/app/host/activities/page.tsx
+++ b/app/host/activities/page.tsx
@@ -1,7 +1,10 @@
-"use client";
-
 import React from "react";
 import HostActivities from "../components/HostActivities";
+
+export const metadata = {
+  title: "活動列表 | 森森不息",
+  description: "查看您主辦的所有活動，管理活動資訊和參與者",
+};
 
 export default function ActivitiesPage() {
   return (

--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -1,7 +1,10 @@
-"use client";
-
 import React from "react";
 import { HostProfile } from "./components/HostProfile";
+
+export const metadata = {
+  title: "主辦方資料 | 森森不息",
+  description: "查看和編輯您的主辦方資料，管理您的活動資訊",
+};
 
 export default function HostPage() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import HeaderNavBar from "@/components/HeaderNavBar";
 import Toast from "@/components/Toast";
 import LayoutContentWrapper from "@/components/LayoutContentWrapper";
 import { getUserInfo } from "@/api/server-components/checkUser"
+import { Metadata } from "next";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -15,7 +16,13 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-  
+export const metadata: Metadata = {
+  title: "森森不息 - 走進森林享受不息的感動",
+  description: "探索露營活動，享受大自然的美好",
+  icons: {
+    icon: '/header/logo_icon.svg'
+  }
+};
 
 export default async function RootLayout({
   children,

--- a/app/member/page.tsx
+++ b/app/member/page.tsx
@@ -2,6 +2,11 @@ import UserInfoForm from "@/components/Member/UserInfoForm"
 import ChangePasswordForm from "@/components/Member/ResetPasswordForm"
 import { memberGetProfile } from "@/api/server-components/member/profile"
 
+export const metadata = {
+  title: "會員資料 | 森森不息",
+  description: "在這裡您可以查看和修改您的會員資料",
+}
+
 export default async function MemberPage() {
   const memberInfo = await memberGetProfile()
   return <div className="member__info__page flex flex-col gap-[1rem]">

--- a/app/member/tickets/page.tsx
+++ b/app/member/tickets/page.tsx
@@ -1,6 +1,11 @@
 import EventTicketList from "@/components/Member/EventTicketList"
 import {memberGetOrders} from "@/api/server-components/member/orders"
 
+export const metadata = {
+    title: "我的活動票卷 | 森森不息",
+    description: "在這裡您可以查看您購買的活動票卷"
+}
+
 export default async function MemberTickets() {
     const ordersPaidResponse = await memberGetOrders('Paid');
     const ordersRefundResponse = await memberGetOrders('Refunded');


### PR DESCRIPTION
調整項目：
1. 在購物車、活動創建、活動列表、主辦方資料、會員資料及票卷頁面中新增 metadata 設定。
2. 為每個頁面提供標題和描述，以提升搜尋引擎優化效果。