### PR TITLE
feat: 增加活動列表API的標籤篩選功能

### DIFF
--- a/app/api/host/events/route.ts
+++ b/app/api/host/events/route.ts
@@ -18,9 +18,19 @@ export async function GET(
       );
     }
 
+    // 取得查詢參數
+    const { searchParams } = new URL(request.url);
+    const tag = searchParams.get('tag');
+
+    // 建構後端 API URL
+    let apiUrl = "/host/events";
+    if (tag && tag.trim() !== '') {
+      apiUrl += `?tag=${encodeURIComponent(tag)}`;
+    }
+
     try {
       // 調用後端 API
-      const response = await axiosInstance.get<GetHostEventsResponse>("/host/events", {
+      const response = await axiosInstance.get<GetHostEventsResponse>(apiUrl, {
         headers: {
           Cookie: `access_token=${accessToken}`,
         },

--- a/swr/events/useSubmitEvent.ts
+++ b/swr/events/useSubmitEvent.ts
@@ -36,7 +36,12 @@ export function useSubmitEvent() {
         );
         
         // 提交成功後，重新驗證相關的 SWR 快取
-        mutate('/api/host/events'); // 主辦方活動列表
+        mutate(
+          (key) => {
+            // 如果 key 是字串且以 '/api/host/events' 開頭，則重新驗證
+            return typeof key === 'string' && key.startsWith('/api/host/events');
+          }
+        );
         
         return response.data;
       } catch (error: unknown) {

--- a/swr/host/useHostEvents.ts
+++ b/swr/host/useHostEvents.ts
@@ -4,13 +4,19 @@ import { GetHostEventsResponse } from '@/types/api/host/events';
 
 /**
  * 取得主辦方活動列表的自定義 Hook
+ * @param {string} [tagId] - 篩選的標籤 ID，空字串或 undefined 表示不篩選
  * @returns {Object} 包含活動資料、載入狀態和錯誤的物件
  */
-export function useHostEvents() {
+export function useHostEvents(tagId?: string) {
+  // 建構前端 API URL，如果有 tagId 就加入 query string
+  const apiUrl = tagId && tagId.trim() !== '' 
+    ? `/api/host/events?tag=${encodeURIComponent(tagId)}`
+    : '/api/host/events';
+
   const { data, error, isLoading, mutate } = useSWR<GetHostEventsResponse>(
-    '/api/host/events',
-    async () => {
-      const response = await axios.get<GetHostEventsResponse>('/api/host/events');
+    apiUrl,
+    async (url: string) => {
+      const response = await axios.get<GetHostEventsResponse>(url);
       return response.data;
     }
   );

--- a/types/api/host/events/index.ts
+++ b/types/api/host/events/index.ts
@@ -1,7 +1,7 @@
 import { SuccessResponse } from '../../response';
 
-// 活動狀態
-export type EventStatus = "草稿" | "已發布" | "已取消" | "已結束";
+// 活動狀態 - 支援中英文對應
+export type EventStatus = "草稿" | "已發布" | "已取消" | "已結束" | "draft" | "pending" | "published" | "archived";
 
 // 通知型別
 export interface EventNotice {


### PR DESCRIPTION
調整項目：
1. 在  請求中加入標籤查詢參數，支持根據標籤篩選活動。
2. 更新  Hook，接受標籤ID作為參數，並構建相應的API URL。
3. 在  組件中，根據選擇的標籤獲取活動資料，並更新顯示邏輯。

這些變更提升了活動列表的靈活性，使用者可以更方便地根據標籤篩選活動。