### PR TITLE
feat: 新增活動下架申請功能及相關元件

### DIFF
--- a/app/api/host/events/request-unpublish/route.ts
+++ b/app/api/host/events/request-unpublish/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axiosInstance from '@/api/axiosIntance';
+import type { RequestUnpublishEventRequest, RequestUnpublishEventResponse } from '@/types/api/host/request-unpublish';
+import type { ErrorResponse } from '@/types/api/response';
+import { formatAxiosError } from '@/utils/errors';
+
+/**
+ * 申請下架活動 API 路由處理器
+ * 修改：將 eventId 從 URL 參數改為請求體參數，避免 Vercel 部署問題
+ */
+export async function PATCH(
+  req: NextRequest
+): Promise<NextResponse<RequestUnpublishEventResponse | ErrorResponse>> {
+  
+  try {
+    // 檢查用戶是否已登入
+    const accessToken = req.headers.get("access_token");
+    
+    if (!accessToken) {
+      return NextResponse.json<ErrorResponse>(
+        { status: "failed", message: "無此權限，請先登入" },
+        { status: 403 }
+      );
+    }
+
+    // 解析請求體，包含 eventId 和 reason
+    let requestBody: RequestUnpublishEventRequest & { eventId: string };
+    
+    try {
+      requestBody = await req.json();
+    } catch (parseError) {
+      console.error("❌ 請求體解析失敗:", parseError);
+      return NextResponse.json<ErrorResponse>(
+        { status: "failed", message: "請求格式錯誤" },
+        { status: 400 }
+      );
+    }
+
+    const { eventId, reason } = requestBody;
+
+    // 檢查活動 ID 是否存在
+    if (!eventId) {
+      return NextResponse.json<ErrorResponse>(
+        { status: "failed", message: "活動 ID 不存在" },
+        { status: 400 }
+      );
+    }
+
+    // 檢查下架原因是否存在
+    if (!reason || reason.trim() === "") {
+      return NextResponse.json<ErrorResponse>(
+        { status: "failed", message: "請提供下架原因" },
+        { status: 400 }
+      );
+    }
+
+    try {
+      // 調用後端 API，只傳送 reason 到後端
+      const response = await axiosInstance.patch<RequestUnpublishEventResponse>(
+        `/host/events/${eventId}/request-unpublish`,
+        { reason },
+        {
+          headers: {
+            Cookie: `access_token=${accessToken}`,
+          },
+          withCredentials: true,
+        }
+      );
+
+      // 返回成功回應
+      return NextResponse.json<RequestUnpublishEventResponse>(response.data);
+      
+    } catch (error: unknown) {
+      
+      // 處理 Axios 錯誤
+      const apiErr = formatAxiosError(error);
+
+      // 依據不同錯誤代碼回傳不同錯誤訊息
+      if (apiErr.httpCode === 400) {
+        return NextResponse.json<ErrorResponse>(
+          { status: "failed", message: "只有已上架活動可以申請下架" },
+          { status: 400 }
+        );
+      } else if (apiErr.httpCode === 403) {
+        // 檢查錯誤訊息來區分不同的 403 錯誤
+        if (apiErr.message.includes("主辦方")) {
+          return NextResponse.json<ErrorResponse>(
+            { status: "failed", message: "無法取得主辦方資料" },
+            { status: 403 }
+          );
+        } else {
+          return NextResponse.json<ErrorResponse>(
+            { status: "failed", message: "無此權限，請先登入" },
+            { status: 403 }
+          );
+        }
+      } else if (apiErr.httpCode === 404) {
+        return NextResponse.json<ErrorResponse>(
+          { status: "error", message: "找不到活動" },
+          { status: 404 }
+        );
+      } else {
+        return NextResponse.json<ErrorResponse>(
+          { status: "error", message: "伺服器錯誤，請稍後再試" },
+          { status: 500 }
+        );
+      }
+    }
+  } catch (error) {
+    console.error("💥 處理申請下架活動時發生嚴重錯誤:", error);
+    
+    return NextResponse.json<ErrorResponse>(
+      { status: "error", message: "伺服器錯誤，請稍後再試" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/Host/RejectEventModal/index.tsx
+++ b/components/Host/RejectEventModal/index.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { useState } from "react";
+import DialogModal from "@/components/DialogModal";
+import { useRequestUnpublishEvent } from "@/swr/host/useRequestUnpublishEvent";
+import toast from "react-hot-toast";
+import clsx from "clsx";
+
+interface Props {
+  modalId: string;
+  modalRef: React.RefObject<HTMLInputElement | null>;
+  eventId: string;
+  eventTitle: string;
+}
+
+export default function RejectEventModal({
+  modalId,
+  modalRef,
+  eventId,
+  eventTitle
+}: Props) {
+  const [rejectReason, setRejectReason] = useState<string>("");
+  const { requestUnpublish, isMutating } = useRequestUnpublishEvent();
+
+  /** 處理退件確認 */
+  async function handleRejectConfirm() {
+    if (!rejectReason.trim()) {
+      toast.error("請輸入退件原因");
+      return;
+    }
+
+    try {
+      await requestUnpublish(eventId, rejectReason.trim());
+      // 成功後關閉 modal 並清空表單
+      handleCloseModal();
+    } catch (error) {
+      console.error("退件失敗:", error);
+      // 錯誤訊息已在 hook 中處理，這裡不需要再次顯示
+    }
+  }
+
+  /** 處理取消並關閉 modal */
+  function handleCloseModal() {
+    if (modalRef.current) {
+      modalRef.current.checked = false;
+    }
+    // 清空退件原因
+    setRejectReason("");
+  }
+
+  return (
+    <DialogModal id={modalId} modalRef={modalRef} modalWidth="max-w-md">
+      <div className="space-y-4">
+        {/* 標題 */}
+        <div className="heading-5 text-[#AB5F5F] font-semibold">
+          申請活動下架
+        </div>
+        
+        {/* 活動資訊 */}
+        <div className="text-sm text-[#6D6D6D]">
+          活動名稱：<span className="text-[#121212]">{eventTitle}</span>
+        </div>
+
+        {/* 退件原因輸入框 */}
+        <div className="space-y-2">
+          <label htmlFor="reject-reason" className="text-sm text-[#121212] font-medium">
+            <span className="text-[#AB5F5F]">*</span> 下架原因
+          </label>
+          <textarea
+            id="reject-reason"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            placeholder="請輸入申請下架的原因..."
+            className="w-full px-3 py-2 border border-[#E7E7E7] rounded-lg text-sm text-[#121212] placeholder-[#B0B0B0] focus:outline-none focus:ring-2 focus:ring-[#5C795F] focus:border-transparent resize-none"
+            rows={4}
+            maxLength={500}
+          />
+          <div className="text-xs text-[#6D6D6D] text-right">
+            {rejectReason.length}/500
+          </div>
+        </div>
+      </div>
+
+      {/* 按鈕區域 */}
+      <div className="modal-action flex gap-3 mt-6">
+        <button
+          onClick={handleCloseModal}
+          disabled={isMutating}
+          className="flex-1 px-4 py-2 border border-[#E7E7E7] text-[#6D6D6D] rounded-lg text-sm font-medium hover:bg-[#F6F6F6] transition-colors disabled:opacity-50"
+        >
+          取消
+        </button>
+        <button
+          onClick={handleRejectConfirm}
+          disabled={isMutating || !rejectReason.trim()}
+          className={clsx(
+            "flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors",
+            "bg-[#5C795F] text-white hover:bg-[#4A6B4D]",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {isMutating ? (
+            <span className="loading loading-spinner loading-sm"></span>
+          ) : (
+            "確認申請"
+          )}
+        </button>
+      </div>
+    </DialogModal>
+  );
+}

--- a/swr/host/useRequestUnpublishEvent.ts
+++ b/swr/host/useRequestUnpublishEvent.ts
@@ -1,0 +1,99 @@
+import useSWRMutation from "swr/mutation";
+import axios from "axios";
+import { RequestUnpublishEventRequest, RequestUnpublishEventResponse } from "@/types/api/host/request-unpublish";
+import toast from "react-hot-toast";
+import { mutate } from "swr";
+
+/**
+ * 用於申請下架活動的自定義 Hook
+ * @returns {Object} 包含觸發函式、載入狀態、錯誤和資料的物件
+ */
+export function useRequestUnpublishEvent() {
+  const { isMutating, trigger: originalTrigger, error, data } = useSWRMutation(
+    // 使用簡化的 API 路由
+    "/api/events/request-unpublish",
+    async (_key: string, { arg }: { arg: RequestUnpublishEventRequest & { eventId: string } }) => {
+      
+      try {
+        // 檢查 eventId 是否存在
+        if (!arg.eventId) {
+          throw new Error("活動 ID 不存在，無法申請下架");
+        }
+        
+        // 檢查原因是否存在
+        if (!arg.reason || arg.reason.trim() === "") {
+          throw new Error("請提供下架原因");
+        }
+        
+        // 準備請求載荷，將 eventId 和 reason 都放在請求體中
+        const requestPayload = {
+          eventId: arg.eventId,
+          reason: arg.reason
+        };
+        
+        const response = await axios.patch<RequestUnpublishEventResponse>(
+          "/api/host/events/request-unpublish",
+          requestPayload,
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+        
+        // 申請成功後，重新驗證相關的 SWR 快取
+        mutate(
+          (key) => {
+            // 如果 key 是字串且以 '/api/host/events' 或 '/api/events' 開頭，則重新驗證
+            return typeof key === 'string' && (
+              key.startsWith('/api/host/events') || 
+              key.startsWith('/api/events')
+            );
+          }
+        );
+        
+        // 顯示成功訊息
+        if (response.data.message) {
+          toast.success(response.data.message);
+        }
+        
+        return response.data;
+      } catch (error: unknown) {
+        console.error("❌ API 請求失敗:", error);
+        
+        if (axios.isAxiosError(error) && error.response) {
+          const errorMessage = error.response.data.message || "申請下架活動失敗";
+          console.error("🚨 Axios 錯誤詳情:", {
+            status: error.response.status,
+            statusText: error.response.statusText,
+            data: error.response.data,
+            message: errorMessage
+          });
+          toast.error(errorMessage);
+          throw new Error(errorMessage);
+        }
+        
+        console.error("🚨 非 Axios 錯誤:", error);
+        const errorMessage = error instanceof Error ? error.message : "申請下架活動發生錯誤";
+        toast.error(errorMessage);
+        throw new Error(errorMessage);
+      }
+    }
+  );
+
+  // 包裝原始 trigger 函數，提供更友好的介面
+  const requestUnpublish = async (eventId: string, reason: string) => {
+    console.log("🎬 [useRequestUnpublishEvent] requestUnpublish 函式被呼叫");
+    console.log("🆔 活動 ID:", eventId);
+    console.log("📝 下架原因:", reason);
+    
+    return originalTrigger({ eventId, reason });
+  };
+
+  return {
+    isMutating,
+    requestUnpublish,
+    data,
+    error,
+  };
+}

--- a/types/api/host/request-unpublish/index.ts
+++ b/types/api/host/request-unpublish/index.ts
@@ -1,0 +1,9 @@
+import { SuccessResponseNoData } from "@/types/api/response";
+
+// 申請下架活動請求參數介面
+export interface RequestUnpublishEventRequest {
+  reason: string;
+}
+
+// 申請下架活動回應介面
+export type RequestUnpublishEventResponse = SuccessResponseNoData;


### PR DESCRIPTION
因應需求，新增申請下架活動的 API 路由及自定義 Hook，並整合至活動管理介面。調整項目包括：
1. 新增  處理下架請求，將 eventId 從 URL 參數改為請求體參數。
2. 新增  Hook，簡化下架請求的邏輯。
3. 新增  元件，提供用戶輸入下架原因的介面。
4. 更新  元件，整合下架申請按鈕及相關狀態管理。