### PR TITLE
Fix/shiba fn plan accordion

### DIFF
--- a/app/create-activity/components/ActivityCreationSuccess.tsx
+++ b/app/create-activity/components/ActivityCreationSuccess.tsx
@@ -203,21 +203,42 @@ function ActivityCreationSuccess({ eventId, onCreateNewActivity }: ActivityCreat
                       )}
                     </div>
                   </div>
-                  <div className="text-sm text-[#4F4F4F] mb-2">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Icon icon="material-symbols:person-add" className="w-4 h-4 text-[#5C795F]" />
+                    <div className="flex items-center gap-1 font-medium text-xs text-[#4F4F4F]">
+                      方案人數：<span className="font-medium text-[#5C795F]">{plan.people_capacity}</span> 人
+                    </div>
+                  </div>
+                  <div className="text-xs text-[#4F4F4F] mb-2">
                     {plan.content && plan.content.length > 0 && (
-                      <ul className="list-disc list-inside space-y-1">
-                        {plan.content.map((item, idx) => (
-                          <li key={idx}>{item.value}</li>
-                        ))}
-                      </ul>
+                      <div>
+                        <div className="flex items-center gap-1 font-medium mb-2">
+                          <Icon icon="material-symbols:checklist" className="w-4 h-4 text-[#5C795F]" />
+                          方案內容：
+                        </div>
+                        <ul className="space-y-1 ml-5">
+                          {plan.content.map((item, idx) => (
+                            <li key={idx} className="flex items-start gap-2">
+                              <Icon icon="material-symbols:check-circle" className="w-3 h-3 text-[#5C795F] mt-0.5 flex-shrink-0" />
+                              <span>{item.value}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
                     )}
                   </div>
                   {plan.addOns && plan.addOns.length > 0 && (
                     <div className="text-xs text-[#4F4F4F]">
-                      <div className="font-medium mb-1">加購項目：</div>
-                      <ul className="list-disc list-inside space-y-1">
+                      <div className="flex items-center gap-1 font-medium mb-2">
+                        <Icon icon="material-symbols:add-shopping-cart" className="w-4 h-4 text-[#5C795F]" />
+                        加購項目：
+                      </div>
+                      <ul className="space-y-1 ml-5">
                         {plan.addOns.map((addon, idx) => (
-                          <li key={idx}>{addon.name} (+{formatPrice(addon.price)})</li>
+                          <li key={idx} className="flex items-start gap-2">
+                            <Icon icon="material-symbols:add-circle" className="w-3 h-3 text-[#5C795F] mt-0.5 flex-shrink-0" />
+                            <span>{addon.name} (+{formatPrice(addon.price)})</span>
+                          </li>
                         ))}
                       </ul>
                     </div>

--- a/app/create-activity/components/CreateActivityForm.tsx
+++ b/app/create-activity/components/CreateActivityForm.tsx
@@ -111,6 +111,7 @@ const CreateActivityForm: React.FC = () => {
           title: '基本方案',
           price: 0,
           discountPrice: 0,
+          people_capacity: 1, // 預設為 1 人方案
           content: [],
           addOns: [],
         },

--- a/app/create-activity/components/PlanAccordion.tsx
+++ b/app/create-activity/components/PlanAccordion.tsx
@@ -62,6 +62,7 @@ const PlanAccordion = forwardRef<PlanAccordionRef, PlanAccordionProps>(
             title: plan.title,
             price: plan.price,
             discounted_price: plan.discountPrice,
+            people_capacity: plan.people_capacity,
             contents: plan.content?.map((item) => item.value) || [],
             addons: plan.addOns || [],
           })),
@@ -84,6 +85,7 @@ const PlanAccordion = forwardRef<PlanAccordionRef, PlanAccordionProps>(
             title: plan.title,
             price: plan.price,
             discounted_price: plan.discountPrice,
+            people_capacity: plan.people_capacity,
             contents: plan.content?.map((item) => item.value) || [],
             addons: plan.addOns || [],
           })),
@@ -168,6 +170,7 @@ const PlanAccordion = forwardRef<PlanAccordionRef, PlanAccordionProps>(
         title: `方案 ${fields.length + 1}`,
         price: 0,
         discountPrice: 0,
+        people_capacity: 1, // 預設為 1 人方案
         content: [{ value: '' }],
         addOns: [],
       });

--- a/app/create-activity/components/PlanAccordionItem.tsx
+++ b/app/create-activity/components/PlanAccordionItem.tsx
@@ -165,6 +165,24 @@ function PlanAccordionItem({
                         />
                       </FormField>
                     </div>
+
+                    {/* 方案人數 */}
+                    <div className="lg:w-40">
+                      <FormField
+                        label="方案人數"
+                        name={`plans.${index}.people_capacity`}
+                        required
+                        error={planErrors?.people_capacity?.message}
+                      >
+                        <FormNumberInput
+                          name={`plans.${index}.people_capacity`}
+                          min={1}
+                          max={20}
+                          step={1}
+                          placeholder="人數"
+                        />
+                      </FormField>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/app/create-activity/components/PlanAccordionItem.tsx
+++ b/app/create-activity/components/PlanAccordionItem.tsx
@@ -82,18 +82,20 @@ function PlanAccordionItem({
         </div>
         <div className="flex items-center gap-2 ml-3">
           {planErrors && (
-            <Icon 
-              icon="material-symbols:error" 
-              className="w-5 h-5 text-[#AB5F5F] animate-pulse" 
+            <Icon
+              icon="material-symbols:error"
+              className="w-5 h-5 text-[#AB5F5F] animate-pulse"
             />
           )}
-          <Icon 
-            icon="material-symbols:keyboard-arrow-down" 
-            className={`w-5 h-5 text-[#5C795F] transition-transform duration-300 ease-in-out ${isExpanded ? 'rotate-180' : 'rotate-0'}`} 
+          <Icon
+            icon="material-symbols:keyboard-arrow-down"
+            className={`w-5 h-5 text-[#5C795F] transition-transform duration-300 ease-in-out ${
+              isExpanded ? 'rotate-180' : 'rotate-0'
+            }`}
           />
         </div>
       </div>
-      
+
       {isExpanded && (
         <div className="border-t border-[#E0E6E0] bg-gradient-to-b from-white to-[#FAFBFA]">
           <div className="p-4 md:p-6">
@@ -103,7 +105,9 @@ function PlanAccordionItem({
                 <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-start">
                   <div className="flex items-center gap-3">
                     <div className="w-2 h-6 bg-[#5C795F] rounded-full"></div>
-                    <h3 className="text-lg font-semibold text-[#121212]">方案基本資訊</h3>
+                    <h3 className="text-lg font-semibold text-[#121212]">
+                      方案基本資訊
+                    </h3>
                   </div>
                   {/* 方案操作按鈕 */}
                   {canDelete && (
@@ -113,7 +117,10 @@ function PlanAccordionItem({
                       onClick={onDelete}
                     >
                       <span className="flex items-center justify-center gap-2">
-                        <Icon icon="material-symbols:delete-outline" className="w-4 h-4" />
+                        <Icon
+                          icon="material-symbols:delete-outline"
+                          className="w-4 h-4"
+                        />
                         刪除方案
                       </span>
                     </button>
@@ -131,6 +138,22 @@ function PlanAccordionItem({
                     <FormInput
                       name={`plans.${index}.title`}
                       placeholder="請輸入方案標題（最多100字）"
+                    />
+                  </FormField>
+
+                  {/* 方案人數 */}
+                  <FormField
+                    label="方案人數"
+                    name={`plans.${index}.people_capacity`}
+                    required
+                    error={planErrors?.people_capacity?.message}
+                  >
+                    <FormNumberInput
+                      name={`plans.${index}.people_capacity`}
+                      min={1}
+                      max={20}
+                      step={1}
+                      placeholder="人數"
                     />
                   </FormField>
 
@@ -165,175 +188,186 @@ function PlanAccordionItem({
                         />
                       </FormField>
                     </div>
-
-                    {/* 方案人數 */}
-                    <div className="lg:w-40">
-                      <FormField
-                        label="方案人數"
-                        name={`plans.${index}.people_capacity`}
-                        required
-                        error={planErrors?.people_capacity?.message}
-                      >
-                        <FormNumberInput
-                          name={`plans.${index}.people_capacity`}
-                          min={1}
-                          max={20}
-                          step={1}
-                          placeholder="人數"
-                        />
-                      </FormField>
-                    </div>
                   </div>
                 </div>
               </div>
 
-            {/* 方案內容 */}
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
-                <div className="flex items-center gap-3">
-                  <div className="w-2 h-6 bg-[#5C795F] rounded-full"></div>
-                  <h3 className="text-lg font-semibold text-[#121212]">方案內容</h3>
+              {/* 方案內容 */}
+              <div className="flex flex-col gap-6">
+                <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
+                  <div className="flex items-center gap-3">
+                    <div className="w-2 h-6 bg-[#5C795F] rounded-full"></div>
+                    <h3 className="text-lg font-semibold text-[#121212]">
+                      方案內容
+                    </h3>
+                  </div>
+                  <button
+                    type="button"
+                    className="w-full md:w-auto px-6 py-3 rounded-2xl bg-[#5C795F] hover:bg-[#4a6651] text-white font-semibold text-sm transition-all duration-200 hover:scale-105"
+                    onClick={handleAddContent}
+                  >
+                    <span className="flex items-center justify-center gap-2">
+                      <Icon icon="material-symbols:add" className="w-4 h-4" />
+                      新增方案內容
+                    </span>
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  className="w-full md:w-auto px-6 py-3 rounded-2xl bg-[#5C795F] hover:bg-[#4a6651] text-white font-semibold text-sm transition-all duration-200 hover:scale-105"
-                  onClick={handleAddContent}
+                <FormField
+                  label="內容項目"
+                  name={`plans.${index}.content`}
+                  required
+                  error={planErrors?.content?.message}
                 >
-                  <span className="flex items-center justify-center gap-2">
-                    <Icon icon="material-symbols:add" className="w-4 h-4" />
-                    新增方案內容
-                  </span>
-                </button>
-              </div>
-              <FormField
-                label="內容項目"
-                name={`plans.${index}.content`}
-                required
-                error={planErrors?.content?.message}
-              >
-                <div className="flex flex-col gap-4">
-                  {contentArray.fields.length === 0 ? (
-                    <div className="text-center py-8 bg-gradient-to-br from-[#F5F7F5] to-[#E8F0E8] rounded-xl border border-dashed border-[#5C795F]/30">
-                      <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-[#5C795F]/10 flex items-center justify-center">
-                        <Icon icon="material-symbols:description-outline" className="w-6 h-6 text-[#5C795F]" />
-                      </div>
-                      <p className="text-[#4F4F4F] text-sm">尚未新增方案內容</p>
-                    </div>
-                  ) : (
-                    contentArray.fields.map((field, contentIndex) => {
-                      const contentError = planErrors?.content?.[contentIndex]?.value?.message;
-                      return (
-                        <div key={field.id} className="flex gap-3 items-start">
-                          <div className="flex-1">
-                            <FormInput
-                              name={`plans.${index}.content.${contentIndex}.value`}
-                              placeholder="請輸入內容項目"
-                            />
-                            {contentError && (
-                              <span className="text-xs font-normal text-[#AB5F5F] leading-[1.5em] font-[Noto_Sans_TC] mt-1 block">
-                                {contentError}
-                              </span>
-                            )}
-                          </div>
-                          <button
-                            type="button"
-                            className="w-12 h-12 flex items-center justify-center rounded-xl border-2 border-[#AB5F5F] text-[#AB5F5F] hover:bg-[#AB5F5F] hover:text-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed hover:scale-105 disabled:hover:scale-100"
-                            onClick={() => contentArray.remove(contentIndex)}
-                            disabled={contentArray.fields.length <= 1}
-                          >
-                            <Icon icon="material-symbols:delete-outline" className="h-4 w-4" />
-                          </button>
+                  <div className="flex flex-col gap-4">
+                    {contentArray.fields.length === 0 ? (
+                      <div className="text-center py-8 bg-gradient-to-br from-[#F5F7F5] to-[#E8F0E8] rounded-xl border border-dashed border-[#5C795F]/30">
+                        <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-[#5C795F]/10 flex items-center justify-center">
+                          <Icon
+                            icon="material-symbols:description-outline"
+                            className="w-6 h-6 text-[#5C795F]"
+                          />
                         </div>
-                      );
-                    })
-                  )}
-                </div>
-              </FormField>
-            </div>
-
-            {/* 加購商品 */}
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
-                <div className="flex items-center gap-3">
-                  <div className="w-2 h-6 bg-[#5C795F] rounded-full"></div>
-                  <h3 className="text-lg font-semibold text-[#121212]">加購商品（可選）</h3>
-                </div>
-                <button
-                  type="button"
-                  className="w-full md:w-auto px-6 py-3 rounded-2xl bg-[#5C795F] hover:bg-[#4a6651] text-white font-semibold text-sm transition-all duration-200 hover:scale-105"
-                  onClick={handleAddAddOn}
-                >
-                  <span className="flex items-center justify-center gap-2">
-                    <Icon icon="material-symbols:add" className="w-4 h-4" />
-                    新增加購商品
-                  </span>
-                </button>
-              </div>
-
-              <FormField
-                label="加購商品"
-                name={`plans.${index}.addOns`}
-                error={planErrors?.addOns?.message}
-              >
-                <div className="flex flex-col gap-4">
-                  {addOnsArray.fields.length === 0 ? (
-                    <div className="text-center py-8 bg-gradient-to-br from-[#F5F7F5] to-[#E8F0E8] rounded-xl border border-dashed border-[#5C795F]/30">
-                      <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-[#5C795F]/10 flex items-center justify-center">
-                        <Icon icon="material-symbols:shopping-bag-outline" className="w-6 h-6 text-[#5C795F]" />
+                        <p className="text-[#4F4F4F] text-sm">
+                          尚未新增方案內容
+                        </p>
                       </div>
-                      <p className="text-[#4F4F4F] text-sm">尚未新增加購商品</p>
-                    </div>
-                  ) : (
-                    addOnsArray.fields.map((field, addOnIndex) => (
-                      <div
-                        key={field.id}
-                        className="flex flex-col gap-4 lg:flex-row lg:items-end p-4 bg-white rounded-xl border border-[#E0E6E0]"
-                      >
-                        <div className="flex-1">
-                          <FormField
-                            label="商品名稱"
-                            name={`plans.${index}.addOns.${addOnIndex}.name`}
-                            required
-                            error={planErrors?.addOns?.[addOnIndex]?.name?.message}
+                    ) : (
+                      contentArray.fields.map((field, contentIndex) => {
+                        const contentError =
+                          planErrors?.content?.[contentIndex]?.value?.message;
+                        return (
+                          <div
+                            key={field.id}
+                            className="flex gap-3 items-start"
                           >
-                            <FormInput
-                              name={`plans.${index}.addOns.${addOnIndex}.name`}
-                              placeholder="商品名稱"
-                            />
-                          </FormField>
-                        </div>
-                        <div className="flex gap-3 items-end">
-                          <div className="w-32">
-                            <FormField
-                              label="商品價格"
-                              name={`plans.${index}.addOns.${addOnIndex}.price`}
-                              required
-                              error={planErrors?.addOns?.[addOnIndex]?.price?.message}
+                            <div className="flex-1">
+                              <FormInput
+                                name={`plans.${index}.content.${contentIndex}.value`}
+                                placeholder="請輸入內容項目"
+                              />
+                              {contentError && (
+                                <span className="text-xs font-normal text-[#AB5F5F] leading-[1.5em] font-[Noto_Sans_TC] mt-1 block">
+                                  {contentError}
+                                </span>
+                              )}
+                            </div>
+                            <button
+                              type="button"
+                              className="w-12 h-12 flex items-center justify-center rounded-xl border-2 border-[#AB5F5F] text-[#AB5F5F] hover:bg-[#AB5F5F] hover:text-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed hover:scale-105 disabled:hover:scale-100"
+                              onClick={() => contentArray.remove(contentIndex)}
+                              disabled={contentArray.fields.length <= 1}
                             >
-                              <FormNumberInput
-                                name={`plans.${index}.addOns.${addOnIndex}.price`}
-                                min={1}
-                                step={1}
-                                placeholder="商品價格"
+                              <Icon
+                                icon="material-symbols:delete-outline"
+                                className="h-4 w-4"
+                              />
+                            </button>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                </FormField>
+              </div>
+
+              {/* 加購商品 */}
+              <div className="flex flex-col gap-6">
+                <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
+                  <div className="flex items-center gap-3">
+                    <div className="w-2 h-6 bg-[#5C795F] rounded-full"></div>
+                    <h3 className="text-lg font-semibold text-[#121212]">
+                      加購商品（可選）
+                    </h3>
+                  </div>
+                  <button
+                    type="button"
+                    className="w-full md:w-auto px-6 py-3 rounded-2xl bg-[#5C795F] hover:bg-[#4a6651] text-white font-semibold text-sm transition-all duration-200 hover:scale-105"
+                    onClick={handleAddAddOn}
+                  >
+                    <span className="flex items-center justify-center gap-2">
+                      <Icon icon="material-symbols:add" className="w-4 h-4" />
+                      新增加購商品
+                    </span>
+                  </button>
+                </div>
+
+                <FormField
+                  label="加購商品"
+                  name={`plans.${index}.addOns`}
+                  error={planErrors?.addOns?.message}
+                >
+                  <div className="flex flex-col gap-4">
+                    {addOnsArray.fields.length === 0 ? (
+                      <div className="text-center py-8 bg-gradient-to-br from-[#F5F7F5] to-[#E8F0E8] rounded-xl border border-dashed border-[#5C795F]/30">
+                        <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-[#5C795F]/10 flex items-center justify-center">
+                          <Icon
+                            icon="material-symbols:shopping-bag-outline"
+                            className="w-6 h-6 text-[#5C795F]"
+                          />
+                        </div>
+                        <p className="text-[#4F4F4F] text-sm">
+                          尚未新增加購商品
+                        </p>
+                      </div>
+                    ) : (
+                      addOnsArray.fields.map((field, addOnIndex) => (
+                        <div
+                          key={field.id}
+                          className="flex flex-col gap-4 lg:flex-row lg:items-end p-4 bg-white rounded-xl border border-[#E0E6E0]"
+                        >
+                          <div className="flex-1">
+                            <FormField
+                              label="商品名稱"
+                              name={`plans.${index}.addOns.${addOnIndex}.name`}
+                              required
+                              error={
+                                planErrors?.addOns?.[addOnIndex]?.name?.message
+                              }
+                            >
+                              <FormInput
+                                name={`plans.${index}.addOns.${addOnIndex}.name`}
+                                placeholder="商品名稱"
                               />
                             </FormField>
                           </div>
-                          <button
-                            type="button"
-                            className="w-12 h-12 flex items-center justify-center rounded-xl border-2 border-[#AB5F5F] text-[#AB5F5F] hover:bg-[#AB5F5F] hover:text-white transition-all duration-200 hover:scale-105"
-                            onClick={() => addOnsArray.remove(addOnIndex)}
-                          >
-                            <Icon icon="material-symbols:delete-outline" className="h-4 w-4" />
-                          </button>
+                          <div className="flex gap-3 items-end">
+                            <div className="w-32">
+                              <FormField
+                                label="商品價格"
+                                name={`plans.${index}.addOns.${addOnIndex}.price`}
+                                required
+                                error={
+                                  planErrors?.addOns?.[addOnIndex]?.price
+                                    ?.message
+                                }
+                              >
+                                <FormNumberInput
+                                  name={`plans.${index}.addOns.${addOnIndex}.price`}
+                                  min={1}
+                                  step={1}
+                                  placeholder="商品價格"
+                                />
+                              </FormField>
+                            </div>
+                            <button
+                              type="button"
+                              className="w-12 h-12 flex items-center justify-center rounded-xl border-2 border-[#AB5F5F] text-[#AB5F5F] hover:bg-[#AB5F5F] hover:text-white transition-all duration-200 hover:scale-105"
+                              onClick={() => addOnsArray.remove(addOnIndex)}
+                            >
+                              <Icon
+                                icon="material-symbols:delete-outline"
+                                className="h-4 w-4"
+                              />
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </FormField>
+                      ))
+                    )}
+                  </div>
+                </FormField>
+              </div>
             </div>
           </div>
-        </div>
         </div>
       )}
     </div>

--- a/app/create-activity/schema/formDataSchema.ts
+++ b/app/create-activity/schema/formDataSchema.ts
@@ -219,7 +219,7 @@ const PlanSchema = z
     title: z.string().min(1, '請輸入方案標題').max(100, '最多100字'),
     price: z.number({ invalid_type_error: '請輸入有效的價格' }).min(1, '方案價格須大於0'),
     discountPrice: z.number({ invalid_type_error: '請輸入有效的價格' }).min(0, '價格不可為負').optional(),
-    people_capacity: z.number({ invalid_type_error: '請輸入有效的人數' }).min(1, '方案人數須大於0').max(20, '方案人數不可超過20人'),
+    people_capacity: z.number({ invalid_type_error: '請輸入有效的人數' }).min(1, '方案人數須大於0'),
     content: z.array(ContentSchema).min(1, '請至少新增一項方案內容'),
     addOns: z.array(AddOnSchema).optional(),
   })
@@ -242,6 +242,18 @@ export const FormDataSchema = z.object({
   coverImages: CoverImageSchema,
   eventImages: EventImagesSchema,
   plans: PlanArraySchema,
+}).superRefine((data, ctx) => {
+  // 驗證每個方案的人數不得超過活動上限人數
+  const maxParticipants = data.eventInfo.max_participants;
+  data.plans.forEach((plan, index) => {
+    if (plan.people_capacity > maxParticipants) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `方案人數不得超過活動上限人數 ${maxParticipants} 人`,
+        path: ['plans', index, 'people_capacity'],
+      });
+    }
+  });
 });
 
 // 編輯模式的表單 schema（圖片為非必填）
@@ -250,6 +262,18 @@ export const FormDataSchemaEdit = z.object({
   coverImages: CoverImageSchemaEdit,
   eventImages: EventImagesSchemaEdit,
   plans: PlanArraySchema,
+}).superRefine((data, ctx) => {
+  // 驗證每個方案的人數不得超過活動上限人數
+  const maxParticipants = data.eventInfo.max_participants;
+  data.plans.forEach((plan, index) => {
+    if (plan.people_capacity > maxParticipants) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `不得超過活動上限人數 ${maxParticipants} 人`,
+        path: ['plans', index, 'people_capacity'],
+      });
+    }
+  });
 });
 
 export type FormData = z.infer<typeof FormDataSchema>;

--- a/app/create-activity/schema/formDataSchema.ts
+++ b/app/create-activity/schema/formDataSchema.ts
@@ -219,6 +219,7 @@ const PlanSchema = z
     title: z.string().min(1, '請輸入方案標題').max(100, '最多100字'),
     price: z.number({ invalid_type_error: '請輸入有效的價格' }).min(1, '方案價格須大於0'),
     discountPrice: z.number({ invalid_type_error: '請輸入有效的價格' }).min(0, '價格不可為負').optional(),
+    people_capacity: z.number({ invalid_type_error: '請輸入有效的人數' }).min(1, '方案人數須大於0').max(20, '方案人數不可超過20人'),
     content: z.array(ContentSchema).min(1, '請至少新增一項方案內容'),
     addOns: z.array(AddOnSchema).optional(),
   })

--- a/app/edit-activity/[eventId]/page.tsx
+++ b/app/edit-activity/[eventId]/page.tsx
@@ -40,6 +40,7 @@ function apiToFormData(apiData: GetHostEventDetailResponse['data']): FormDataEdi
     title: plan.title,
     price: plan.price,
     discountPrice: plan.discounted_price ?? 0,
+    people_capacity: plan.people_capacity ?? 1, // 新增 people_capacity 欄位，預設為 1
     content: plan.eventPlanContentBox?.map(content => ({
       value: content.content
     })) || [],

--- a/app/edit-activity/components/EditSuccessPage.tsx
+++ b/app/edit-activity/components/EditSuccessPage.tsx
@@ -175,21 +175,42 @@ function EditSuccessPage({
                       )}
                     </div>
                   </div>
+                  <div className="flex items-center gap-1 mb-2">
+                    <Icon icon="material-symbols:person-add" className="w-4 h-4 text-[#5C795F]" />
+                    <div className="flex items-center gap-1 font-medium text-xs text-[#4F4F4F]">
+                      方案人數：<span className="font-medium text-[#5C795F]">{plan.people_capacity}</span> 人
+                    </div>
+                  </div>
                   <div className="text-sm text-[#4F4F4F] mb-2">
                     {plan.content && plan.content.length > 0 && (
-                      <ul className="list-disc list-inside space-y-1">
-                        {plan.content.map((item, idx) => (
-                          <li key={idx}>{item.value}</li>
-                        ))}
-                      </ul>
+                      <div className="text-xs text-[#4F4F4F]">
+                        <div className="flex items-center gap-1 font-medium mb-2">
+                          <Icon icon="material-symbols:checklist" className="w-4 h-4 text-[#5C795F]" />
+                          方案內容：
+                        </div>
+                        <ul className="space-y-1 ml-5">
+                          {plan.content.map((item, idx) => (
+                            <li key={idx} className="flex items-start gap-2">
+                              <Icon icon="material-symbols:check-circle" className="w-3 h-3 text-[#5C795F] mt-0.5 flex-shrink-0" />
+                              <span>{item.value}</span>
+                            </li>
+                          ))}
+                        </ul>
+                        </div>
                     )}
                   </div>
                   {plan.addOns && plan.addOns.length > 0 && (
                     <div className="text-xs text-[#4F4F4F]">
-                      <div className="font-medium mb-1">加購項目：</div>
-                      <ul className="list-disc list-inside space-y-1">
+                      <div className="flex items-center gap-1 font-medium mb-2">
+                        <Icon icon="material-symbols:add-shopping-cart" className="w-4 h-4 text-[#5C795F]" />
+                        加購項目：
+                      </div>
+                      <ul className="space-y-1 ml-5">
                         {plan.addOns.map((addon, idx) => (
-                          <li key={idx}>{addon.name} (+{formatPrice(addon.price)})</li>
+                          <li key={idx} className="flex items-start gap-2">
+                            <Icon icon="material-symbols:add-circle" className="w-3 h-3 text-[#5C795F] mt-0.5 flex-shrink-0" />
+                            <span>{addon.name} (+{formatPrice(addon.price)})</span>
+                          </li>
                         ))}
                       </ul>
                     </div>

--- a/types/api/events/index.ts
+++ b/types/api/events/index.ts
@@ -116,6 +116,7 @@ export interface EventPlanRequest {
   title: string;
   price: number;
   discounted_price?: number;
+  people_capacity: number;
   contents: string[];
   addons: EventPlanAddon[];
 }
@@ -126,6 +127,7 @@ export interface EventPlan {
   title: string;
   price: number;
   discounted_price: number | null;
+  people_capacity: number;
   contents: string[];
   addons: EventPlanAddon[];
 }
@@ -147,6 +149,7 @@ export interface UpdateEventPlanRequest {
   title: string;
   price: number;
   discounted_price?: number;
+  people_capacity: number;
   contents: string[];
   addons: EventPlanAddon[];
 }

--- a/types/api/host/eventDetail/index.ts
+++ b/types/api/host/eventDetail/index.ts
@@ -67,6 +67,7 @@ export interface EventPlanDetail {
   title: string;
   price: number;
   discounted_price: number | null;
+  people_capacity: number;
   created_at: string;
   updated_at: string;
   eventPlanContentBox: EventPlanContentDetail[];


### PR DESCRIPTION
update: 更新活動方案頁面，新增方案人數顯示與內容項目格式化

- 在活動建立成功頁面與編輯成功頁面中，新增顯示方案人數的功能，並使用圖示強調。
- 調整方案內容的顯示格式，使用圖示來標示每個內容項目，提升可讀性。
- 在方案加購項目中，使用圖示來標示每個加購項目，增強視覺效果。
- 更新表單驗證邏輯，確保方案人數不超過活動上限，並提供相應的錯誤提示。